### PR TITLE
Add lease-based ghost room cleanup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,9 @@
+node_modules/
+.next/
+dist/
+build/
+coverage/
+playwright-report/
+test-results/
+*.min.js
+

--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,17 @@
 
 # production
 /build
+dist/
 .env
+.env*
 
 # misc
 .DS_Store
+Thumbs.db
+*.tmp
+*.swp
+.vscode/
+.idea/
 *.pem
 
 # debug

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+node_modules/
+.next/
+dist/
+build/
+coverage/
+playwright-report/
+test-results/
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/001-reaction-battle-web-mode"
+  "feature_directory": "specs/002-cleanup-ghost-rooms"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,5 +26,5 @@ This repository is the active production web app for Click Battle.
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read specs/001-reaction-battle-web-mode/plan.md
+shell commands, and other important information, read specs/002-cleanup-ghost-rooms/plan.md
 <!-- SPECKIT END -->

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 "use client";
-import {getDatabase, onValue, ref, remove} from "@firebase/database";
+import {getDatabase, onValue, ref} from "@firebase/database";
 import {assessRoomJoin, GameUser} from "@leandrolescano/click-battle-core";
 import {getAnalytics, logEvent} from "firebase/analytics";
 import dynamic from "next/dynamic";
@@ -18,8 +18,15 @@ import {NotificationType} from "components-new/NotificationModal/types";
 import {WelcomeMessage} from "components-new/WelcomeMessage";
 import {useAuth} from "contexts/AuthContext";
 import {useGame} from "contexts/GameContext";
-import {Game} from "interfaces";
-import {isHostDisconnectStale} from "lib/game/hostPresence";
+import {Game, HostDisconnectSignal} from "interfaces";
+import {
+  deleteRoomIfStillStale,
+  partitionRoomSnapshots
+} from "lib/game/roomCleanup";
+import {
+  estimateServerNow,
+  useServerTimeOffset
+} from "lib/game/serverTimeOffset";
 
 type ListedGameSnapshot = Partial<Game> & {
   hostDisconnectedAt?: number;
@@ -50,6 +57,7 @@ const Home = () => {
   const db = getDatabase();
   const {gameUser, user, loading} = useAuth();
   const {resetGame, setGame, setHasEnteredPassword} = useGame();
+  const serverTimeOffset = useServerTimeOffset();
   const {t} = useTranslation();
 
   useEffect(() => {
@@ -77,6 +85,12 @@ const Home = () => {
 
   useEffect(() => {
     let mounted = true;
+    let latestList: Record<string, ListedGameSnapshot> | null = null;
+    let latestSignals: Record<
+      string,
+      Record<string, HostDisconnectSignal>
+    > | null = null;
+    let evaluationTimeout: number | null = null;
 
     //Get rooms of games from DB
     if (gameUser?.username) {
@@ -84,8 +98,25 @@ const Home = () => {
     }
 
     const refGames = ref(db, `games`);
-    const unsubscribe = onValue(refGames, (snapshot) => {
-      const list: Record<string, ListedGameSnapshot> | null = snapshot.val();
+    const getServerNow = () => estimateServerNow(serverTimeOffset);
+
+    const clearEvaluationTimeout = () => {
+      if (evaluationTimeout !== null) {
+        window.clearTimeout(evaluationTimeout);
+        evaluationTimeout = null;
+      }
+    };
+
+    const evaluateList = (
+      list: Record<string, ListedGameSnapshot> | null,
+      disconnectSignals: Record<
+        string,
+        Record<string, HostDisconnectSignal>
+      > | null = latestSignals
+    ) => {
+      latestList = list;
+      latestSignals = disconnectSignals;
+      clearEvaluationTimeout();
 
       if (!list) {
         setListGames([]);
@@ -96,15 +127,11 @@ const Home = () => {
         return;
       }
 
-      const now = Date.now();
-      const staleRoomKeys: string[] = [];
-      const games = Object.entries(list)
+      const now = getServerNow();
+      const {nextEvaluationAt, staleRoomKeys, visibleEntries} =
+        partitionRoomSnapshots(list, disconnectSignals, now);
+      const games = visibleEntries
         .map(([key, rawGame]) => {
-          if (isHostDisconnectStale(rawGame.hostDisconnectedAt, now)) {
-            staleRoomKeys.push(key);
-            return null;
-          }
-
           if (!gameUser?.username) {
             return null;
           }
@@ -133,15 +160,52 @@ const Home = () => {
 
       setListGames(games);
       staleRoomKeys.forEach((key) => {
-        remove(ref(db, `games/${key}`)).catch(console.error);
+        const rawRoom = list[key];
+        const currentSessionId =
+          rawRoom?.hostLease &&
+          typeof rawRoom.hostLease === "object" &&
+          typeof rawRoom.hostLease.sessionId === "string"
+            ? rawRoom.hostLease.sessionId
+            : null;
+        const observedDisconnectedAt =
+          currentSessionId &&
+          disconnectSignals?.[key]?.[currentSessionId]?.disconnectedAt
+            ? disconnectSignals[key][currentSessionId].disconnectedAt
+            : null;
+
+        deleteRoomIfStillStale(db, key, getServerNow, {
+          expectedSessionId: currentSessionId,
+          observedDisconnectedAt
+        }).catch(console.error);
       });
+
+      if (nextEvaluationAt !== null) {
+        evaluationTimeout = window.setTimeout(
+          () => {
+            evaluateList(latestList, latestSignals);
+          },
+          Math.max(0, nextEvaluationAt - getServerNow())
+        );
+      }
+    };
+
+    const unsubscribeRooms = onValue(refGames, (snapshot) => {
+      evaluateList(snapshot.val(), latestSignals);
     });
+    const unsubscribeSignals = onValue(
+      ref(db, "roomHostDisconnects"),
+      (snapshot) => {
+        evaluateList(latestList, snapshot.val());
+      }
+    );
 
     return () => {
       mounted = false;
-      unsubscribe();
+      clearEvaluationTimeout();
+      unsubscribeRooms();
+      unsubscribeSignals();
     };
-  }, [gameUser?.username]);
+  }, [db, gameUser?.username, serverTimeOffset]);
 
   //Function for enter room
   const handleEnterGame = (game: Game) => {

--- a/components-new/CreateSection/index.tsx
+++ b/components-new/CreateSection/index.tsx
@@ -5,7 +5,6 @@ import {
 } from "@leandrolescano/click-battle-core";
 import {getAnalytics, logEvent} from "firebase/analytics";
 import {
-  child,
   get,
   getDatabase,
   push,
@@ -31,10 +30,14 @@ import {
   isReactionMode,
   SUPPORTED_WEB_GAME_MODES
 } from "lib/game/gameModes";
+import {buildInitialHostLease, createHostSessionId} from "lib/game/hostLease";
 import logoAnim from "lotties/logo-animated.json";
 import {AVAILABLE_TIMES, DEFAULT_VALUES} from "resources/constants";
 import {sha256} from "services/encode";
 import {range} from "utils/numbers";
+
+const getStoredHostSessionKey = (roomId: string) =>
+  `host-room-session:${roomId}`;
 
 export const CreateSection = () => {
   const [creating, setCreating] = useState(false);
@@ -79,6 +82,8 @@ export const CreateSection = () => {
       if (gameUser && room) {
         setCreating(true);
         const newGameRef = ref(db, "games/");
+        const newRoomRef = push(newGameRef);
+        const roomId = newRoomRef.key;
 
         const userToPush: GameUser = {
           username: gameUser.username,
@@ -128,15 +133,20 @@ export const CreateSection = () => {
           reactionSession: null
         };
 
-        objRoom.key = push(newGameRef, objRoom).key;
-        const childNewGame = child(
-          newGameRef,
-          `${objRoom.key}/listUsers/${user?.uid}`
-        );
+        if (roomId && user?.uid) {
+          const sessionId = createHostSessionId(user.uid);
+          objRoom.key = roomId;
 
-        await set(childNewGame, userToPush);
+          await set(ref(db, `games/${roomId}`), {
+            ...objRoom,
+            listUsers: {
+              [user.uid]: userToPush
+            },
+            hostLease: buildInitialHostLease(user.uid, sessionId)
+          });
 
-        if (objRoom.key) {
+          sessionStorage.setItem(getStoredHostSessionKey(roomId), sessionId);
+
           logEvent(getAnalytics(), "create_room", {
             action: "create_room",
             withCustomName: !!room.name,
@@ -148,12 +158,12 @@ export const CreateSection = () => {
 
           setGame({
             ...objRoom,
-            key: objRoom.key
+            key: roomId
           });
 
           sessionStorage.setItem("gameUserKey", "0");
 
-          router.push("/game/" + objRoom.key);
+          router.push("/game/" + roomId);
         } else {
           Swal.fire({
             icon: "error",

--- a/contexts/GameContext.tsx
+++ b/contexts/GameContext.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import {GameUser} from "@leandrolescano/click-battle-core";
-import React, {useState, useContext, createContext, useEffect} from "react";
+import React, {
+  useState,
+  useContext,
+  createContext,
+  useEffect,
+  useCallback,
+  useMemo
+} from "react";
 import {useTranslation} from "react-i18next";
 
 import {FinalResults, Game} from "interfaces";
@@ -95,9 +102,9 @@ function useGameProvider(): GameContextState {
     sessionStorage.setItem("game", JSON.stringify(game));
   }, [game]);
 
-  const calculatePosition = () => {
+  const calculatePosition = useCallback(() => {
     const position =
-      game.listUsers
+      [...game.listUsers]
         .sort((a, b) => (b.clicks || 0) - (a.clicks || 0))
         .findIndex((user) => user.key === localUser.key) + 1;
 
@@ -106,35 +113,48 @@ function useGameProvider(): GameContextState {
       localPositionSuffix: getSuffixPosition(position, t),
       results: game.listUsers
     });
-  };
+  }, [game.listUsers, localUser.key, t]);
 
-  const setPartialGame = (partialGame: Partial<Game>) => {
+  const setPartialGame = useCallback((partialGame: Partial<Game>) => {
     setGame((prev) => ({...prev, ...partialGame}));
-  };
+  }, []);
 
-  const resetGame = () => {
+  const resetGame = useCallback(() => {
     setGame(initialGame);
-  };
+  }, []);
 
-  const resetContext = () => {
+  const resetContext = useCallback(() => {
     setGame(initialGame);
     setFinalResults(undefined);
     setLocalUser({username: "", clicks: 0});
     setIsHost(false);
-  };
+  }, []);
 
-  return {
-    game,
-    localUser,
-    isHost,
-    hasEnteredPassword,
-    finalResults,
-    setHasEnteredPassword,
-    setGame: setPartialGame,
-    setLocalUser,
-    resetGame,
-    setIsHost,
-    calculatePosition,
-    resetContext
-  };
+  return useMemo(
+    () => ({
+      game,
+      localUser,
+      isHost,
+      hasEnteredPassword,
+      finalResults,
+      setHasEnteredPassword,
+      setGame: setPartialGame,
+      setLocalUser,
+      resetGame,
+      setIsHost,
+      calculatePosition,
+      resetContext
+    }),
+    [
+      game,
+      localUser,
+      isHost,
+      hasEnteredPassword,
+      finalResults,
+      setPartialGame,
+      resetGame,
+      calculatePosition,
+      resetContext
+    ]
+  );
 }

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,7 +1,29 @@
 {
   /* Visit https://firebase.google.com/docs/database/security to learn more about security rules. */
   "rules": {
-    ".read": false,
-    ".write": false
+    ".read": "false",
+    ".write": "false",
+    "games": {
+      ".read": "auth !== null",
+      ".write": "auth !== null"
+    },
+    "roomHostDisconnects": {
+      "$gameId": {
+        ".read": "auth !== null",
+        ".write": "auth !== null"
+      }
+    },
+    "gamesList": {
+      ".read": "auth !== null",
+      ".write": "auth !== null"
+    },
+    "users": {
+      ".read": "auth !== null",
+      ".write": "auth !== null"
+    },
+    "config": {
+      ".read": "auth !== null",
+      ".write": "auth !== null"
+    }
   }
 }

--- a/firebase.rules-check.json
+++ b/firebase.rules-check.json
@@ -1,0 +1,16 @@
+{
+  "emulators": {
+    "auth": {
+      "port": 9098
+    },
+    "database": {
+      "port": 9001
+    },
+    "ui": {
+      "enabled": false
+    }
+  },
+  "database": {
+    "rules": "database.rules.json"
+  }
+}

--- a/hooks/useRoomGame.ts
+++ b/hooks/useRoomGame.ts
@@ -1,4 +1,5 @@
 import {
+  DataSnapshot,
   getDatabase,
   onDisconnect,
   onValue,
@@ -6,8 +7,7 @@ import {
   remove,
   serverTimestamp,
   set,
-  Unsubscribe,
-  update
+  Unsubscribe
 } from "@firebase/database";
 import {Timestamp} from "firebase/firestore";
 import {useParams, useRouter, useSearchParams} from "next/navigation";
@@ -23,15 +23,45 @@ import {Game} from "interfaces";
 import {UseRoomGameReturn} from "interfaces/RoomGame";
 import {RoomStats} from "interfaces/RoomStats";
 import {DEFAULT_GAME_MODE} from "lib/game/gameModes";
+import {
+  bootstrapLegacyHostLease,
+  clearHostDisconnectSignal,
+  createHostSessionId,
+  getHostDisconnectSignalPath,
+  HOST_LEASE_HEARTBEAT_MS,
+  replaceHostLeaseSession,
+  renewHostLease
+} from "lib/game/hostLease";
+import {assessRoomLifecycle} from "lib/game/hostPresence";
+import {deleteRoomIfStillStale} from "lib/game/roomCleanup";
+import {
+  estimateServerNow,
+  useServerTimeOffset
+} from "lib/game/serverTimeOffset";
 import {breadcrumb, metricCounter, withSpan} from "observability/sentry";
 import {addRoomStats} from "services/rooms";
 import {handleInvite as handleInviteUtil} from "utils/invite";
 
 import {applyState} from "../lib/game/applyState";
-import {getHostDisconnectRemovalDelay} from "../lib/game/hostPresence";
 import {determineJoinAction} from "../lib/game/joinFlow";
 import {reportApplyStateTime} from "../lib/game/metrics";
 import {processSnapshot} from "../lib/game/processSnapshot";
+
+const getStoredHostSessionKey = (roomId: string) =>
+  `host-room-session:${roomId}`;
+
+type RawRoomSnapshot = Record<string, unknown> | null;
+type DisconnectSignalMap = Record<string, {disconnectedAt?: number}> | null;
+
+const getCurrentLeaseSessionId = (rawRoom: RawRoomSnapshot) => {
+  if (!rawRoom?.hostLease || typeof rawRoom.hostLease !== "object") {
+    return null;
+  }
+
+  const candidate = rawRoom.hostLease as {sessionId?: unknown};
+
+  return typeof candidate.sessionId === "string" ? candidate.sessionId : null;
+};
 
 export const useRoomGame = (): UseRoomGameReturn => {
   const router = useRouter();
@@ -62,198 +92,377 @@ export const useRoomGame = (): UseRoomGameReturn => {
     withPassword: false
   });
   const flagEnter = useRef(false);
-  const hostPresenceIdRef = useRef<string>("");
+  const hostHeartbeatIntervalRef = useRef<number | null>(null);
+  const hostSessionIdRef = useRef<string>("");
   const staleHostRemovalTimeoutRef = useRef<number | null>(null);
+  const serverTimeOffsetRef = useRef(0);
   const [error, setError] = useState<Error | null>(null);
 
   const {setNewUser} = useNewPlayerAlert(currentGame.listUsers, localUser);
   const isMobileDevice = useIsMobileDevice();
+  const serverTimeOffset = useServerTimeOffset();
   const {t} = useTranslation();
 
-  // Keep latest game ref updated
+  useEffect(() => {
+    serverTimeOffsetRef.current = serverTimeOffset;
+  }, [serverTimeOffset]);
+
   useEffect(() => {
     latestGameRef.current = currentGame;
   }, [currentGame]);
 
-  // Handle Disconnect
-  useEffect(() => {
-    if (isAuthenticated && gUser?.uid && currentGame.key) {
-      const gamePath = `games/${currentGame.key}`;
-      const userPath = `games/${currentGame.key}/listUsers/${gUser.uid}`;
-
-      if (gameUser?.username === currentGame.ownerUser.username) {
-        if (!hostPresenceIdRef.current) {
-          hostPresenceIdRef.current = `${gUser.uid}-${Date.now()}`;
-        }
-
-        const gameRef = ref(db, gamePath);
-        const disconnect = onDisconnect(gameRef);
-
-        update(gameRef, {
-          hostConnectionId: hostPresenceIdRef.current,
-          hostDisconnectedAt: null
-        }).catch(console.error);
-
-        disconnect
-          .cancel()
-          .then(() =>
-            disconnect.update({
-              hostConnectionId: hostPresenceIdRef.current,
-              hostDisconnectedAt: serverTimestamp()
-            })
-          )
-          .catch(console.error);
-
-        return;
-      } else {
-        onDisconnect(ref(db, userPath)).remove().catch(console.error);
-        return () => {
-          remove(ref(db, userPath));
-        };
-      }
+  const stopHostHeartbeat = useCallback(() => {
+    if (hostHeartbeatIntervalRef.current !== null) {
+      window.clearInterval(hostHeartbeatIntervalRef.current);
+      hostHeartbeatIntervalRef.current = null;
     }
+  }, []);
+
+  const getOrCreateHostSessionId = useCallback(
+    (roomId: string, ownerId: string) => {
+      if (hostSessionIdRef.current) {
+        return hostSessionIdRef.current;
+      }
+
+      const storageKey = getStoredHostSessionKey(roomId);
+      const storedSessionId =
+        typeof window !== "undefined"
+          ? sessionStorage.getItem(storageKey)
+          : null;
+      const sessionId = storedSessionId || createHostSessionId(ownerId);
+
+      hostSessionIdRef.current = sessionId;
+      if (typeof window !== "undefined") {
+        sessionStorage.setItem(storageKey, sessionId);
+      }
+
+      return sessionId;
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!isAuthenticated || !gUser?.uid || !currentGame.key) {
+      return;
+    }
+
+    const userPath = `games/${currentGame.key}/listUsers/${gUser.uid}`;
+
+    if (gameUser?.username === currentGame.ownerUser.username) {
+      const sessionId = getOrCreateHostSessionId(currentGame.key, gUser.uid);
+      const signalRef = ref(
+        db,
+        getHostDisconnectSignalPath(currentGame.key, sessionId)
+      );
+      const disconnect = onDisconnect(signalRef);
+
+      clearHostDisconnectSignal(db, currentGame.key, sessionId).catch(
+        console.error
+      );
+
+      disconnect
+        .cancel()
+        .then(() =>
+          disconnect.set({
+            disconnectedAt: serverTimestamp()
+          })
+        )
+        .catch(console.error);
+
+      return () => {
+        disconnect.cancel().catch(console.error);
+      };
+    }
+
+    onDisconnect(ref(db, userPath)).remove().catch(console.error);
+
+    return () => {
+      remove(ref(db, userPath)).catch(console.error);
+    };
   }, [
-    isAuthenticated,
-    gUser?.uid,
     currentGame.key,
     currentGame.ownerUser.username,
     db,
-    gameUser?.username
+    gameUser?.username,
+    gUser?.uid,
+    getOrCreateHostSessionId,
+    isAuthenticated
   ]);
 
-  // Main Game Logic
   useEffect(() => {
     if (!isAuthenticated || !gameID) return;
 
-    let unsubscribe: Unsubscribe;
+    let latestRoomRaw: RawRoomSnapshot = null;
+    let latestSignalRaw: DisconnectSignalMap = null;
+    let unsubscribeRoom: Unsubscribe | undefined;
+    let unsubscribeSignals: Unsubscribe | undefined;
+
+    const getServerNow = () => estimateServerNow(serverTimeOffsetRef.current);
 
     const clearStaleHostRemoval = () => {
-      if (staleHostRemovalTimeoutRef.current) {
+      if (staleHostRemovalTimeoutRef.current !== null) {
         window.clearTimeout(staleHostRemovalTimeoutRef.current);
         staleHostRemovalTimeoutRef.current = null;
       }
     };
 
-    try {
-      const gameRef = ref(db, `games/${gameID}/`);
+    const scheduleLifecycleReevaluation = (cleanupAt: number | null) => {
+      clearStaleHostRemoval();
 
-      unsubscribe = onValue(gameRef, (snapshot) => {
-        withSpan("onValue_snapshot", () => {
-          const raw = snapshot.val();
-          const key = snapshot.key;
+      if (cleanupAt === null) {
+        return;
+      }
 
-          const {parsed} = processSnapshot(raw, key, gUser?.uid, gameID);
+      staleHostRemovalTimeoutRef.current = window.setTimeout(
+        () => {
+          applyRoomSnapshot(latestRoomRaw, latestSignalRaw);
+        },
+        Math.max(0, cleanupAt - getServerNow())
+      );
+    };
 
-          if (!parsed) {
-            router.replace("/");
+    const syncHostLeaseOwnership = async (
+      rawRoom: RawRoomSnapshot,
+      parsedIsHost: boolean
+    ) => {
+      if (!parsedIsHost || !gUser?.uid || !rawRoom) {
+        stopHostHeartbeat();
+        return;
+      }
+
+      const sessionId = getOrCreateHostSessionId(gameID, gUser.uid);
+      const rawLease =
+        rawRoom.hostLease && typeof rawRoom.hostLease === "object"
+          ? (rawRoom.hostLease as {
+              ownerId?: unknown;
+              sessionId?: unknown;
+            })
+          : null;
+
+      if (!rawLease) {
+        await bootstrapLegacyHostLease(db, gameID, gUser.uid, sessionId).catch(
+          console.error
+        );
+        stopHostHeartbeat();
+        return;
+      }
+
+      if (rawLease.ownerId !== gUser.uid) {
+        stopHostHeartbeat();
+        return;
+      }
+
+      if (rawLease.sessionId !== sessionId) {
+        const previousSessionId =
+          typeof rawLease.sessionId === "string" ? rawLease.sessionId : null;
+        const replacement = await replaceHostLeaseSession(
+          db,
+          gameID,
+          gUser.uid,
+          sessionId
+        ).catch((error) => {
+          console.error(error);
+          return null;
+        });
+
+        if (!replacement?.committed) {
+          stopHostHeartbeat();
+          return;
+        }
+
+        if (previousSessionId) {
+          await clearHostDisconnectSignal(db, gameID, previousSessionId).catch(
+            console.error
+          );
+        }
+
+        await clearHostDisconnectSignal(db, gameID, sessionId).catch(
+          console.error
+        );
+        stopHostHeartbeat();
+        return;
+      }
+
+      await clearHostDisconnectSignal(db, gameID, sessionId).catch(
+        console.error
+      );
+
+      if (hostHeartbeatIntervalRef.current !== null) {
+        return;
+      }
+
+      hostHeartbeatIntervalRef.current = window.setInterval(() => {
+        renewHostLease(db, gameID, gUser.uid, sessionId)
+          .then((result) => {
+            if (!result.committed) {
+              stopHostHeartbeat();
+              return;
+            }
+
+            clearHostDisconnectSignal(db, gameID, sessionId).catch(
+              console.error
+            );
+          })
+          .catch((renewError) => {
+            console.error(renewError);
+            stopHostHeartbeat();
+          });
+      }, HOST_LEASE_HEARTBEAT_MS);
+    };
+
+    const applyRoomSnapshot = (
+      raw: RawRoomSnapshot,
+      signalMap: DisconnectSignalMap
+    ) => {
+      latestRoomRaw = raw;
+      latestSignalRaw = signalMap;
+
+      withSpan("onValue_snapshot", () => {
+        if (!raw) {
+          stopHostHeartbeat();
+          router.replace("/");
+          return;
+        }
+
+        const {parsed} = processSnapshot(raw, gameID, gUser?.uid, gameID);
+
+        if (!parsed) {
+          stopHostHeartbeat();
+          router.replace("/");
+          return;
+        }
+
+        const {
+          game,
+          listUsers,
+          localUser: dbLocalUser,
+          isHost: parsedIsHost
+        } = parsed;
+        const currentLeaseSessionId = getCurrentLeaseSessionId(raw);
+        const lifecycle = assessRoomLifecycle(
+          {
+            ...raw,
+            hostDisconnectSignal: currentLeaseSessionId
+              ? signalMap?.[currentLeaseSessionId] ?? null
+              : null
+          },
+          getServerNow()
+        );
+
+        scheduleLifecycleReevaluation(lifecycle.cleanupAt);
+        syncHostLeaseOwnership(raw, parsedIsHost).catch(console.error);
+
+        if (!parsedIsHost && lifecycle.mayDelete) {
+          stopHostHeartbeat();
+          deleteRoomIfStillStale(db, gameID, getServerNow, {
+            expectedSessionId: lifecycle.expectedSessionId,
+            observedDisconnectedAt: lifecycle.observedDisconnectedAt
+          }).catch(console.error);
+          router.replace("/");
+          return;
+        }
+
+        const startApply = performance.now();
+        try {
+          const {shouldRedirect, newUserJoined} = applyState(
+            parsed,
+            latestGameRef.current.listUsers.length,
+            roomStats.current,
+            gameID
+          );
+
+          if (shouldRedirect) {
+            router.push(shouldRedirect);
             return;
           }
 
-          const {
-            game,
+          const nextGame = game as Game;
+
+          setGame({
+            ...nextGame,
             listUsers,
-            localUser: dbLocalUser,
-            isHost: parsedIsHost
-          } = parsed;
+            reactionSession: nextGame.reactionSession ?? null
+          });
+          if (dbLocalUser) setLocalUser(dbLocalUser);
+          setIsHost(parsedIsHost);
+          if (newUserJoined) setNewUser(true);
 
-          const startApply = performance.now();
-          try {
-            clearStaleHostRemoval();
+          const action = determineJoinAction(
+            parsed,
+            hasEnteredPassword || false,
+            flagEnter.current,
+            query.get("pwd"),
+            gameID
+          );
 
-            const staleHostRemovalDelay = getHostDisconnectRemovalDelay(
-              raw?.hostDisconnectedAt
-            );
-
-            if (!parsedIsHost && staleHostRemovalDelay !== null) {
-              staleHostRemovalTimeoutRef.current = window.setTimeout(() => {
-                remove(gameRef).catch(console.error);
-              }, staleHostRemovalDelay);
-            }
-
-            const {shouldRedirect, newUserJoined} = applyState(
-              parsed,
-              latestGameRef.current.listUsers.length,
-              roomStats.current,
-              gameID
-            );
-
-            if (shouldRedirect) {
-              router.push(shouldRedirect);
-              return;
-            }
-
-            const nextGame = game as Game;
-
-            setGame({
-              ...nextGame,
-              listUsers,
-              reactionSession: nextGame.reactionSession ?? null
-            });
-            if (dbLocalUser) setLocalUser(dbLocalUser);
-            setIsHost(parsedIsHost);
-            if (newUserJoined) setNewUser(true);
-
-            const action = determineJoinAction(
-              parsed,
-              hasEnteredPassword || false,
-              flagEnter.current,
-              query.get("pwd"),
-              gameID
-            );
-
-            if (action.redirect) {
-              router.push(action.redirect);
-              return;
-            }
-
-            if (action.showPasswordPrompt) {
-              requestPassword(game.settings.password!, t).then((val) => {
-                if (val.isConfirmed) {
-                  flagEnter.current = true;
-                  setHasEnteredPassword(true);
-                  router.replace(`/game/${gameID}`); // Clear path
-                  metricCounter("room_join_attempts", undefined, {
-                    room_id: gameID,
-                    is_host: "0"
-                  });
-                  addNewUserToDB(game);
-                } else {
-                  router.push("/");
-                }
-              });
-            } else if (action.addUser) {
-              flagEnter.current = true;
-
-              if (action.metricEvent) {
-                metricCounter(
-                  action.metricEvent.name,
-                  undefined,
-                  action.metricEvent.tags
-                );
-              }
-
-              if (query.get("pwd")) {
-                router.replace(`/game/${gameID}`);
-              }
-              addNewUserToDB(game);
-            }
-          } catch (err) {
-            breadcrumb("error", "snapshot_processing_error", {
-              gameID,
-              error: err
-            });
-
-            throw err;
-          } finally {
-            reportApplyStateTime(
-              performance.now() - startApply,
-              gameID,
-              parsedIsHost,
-              game.gameMode ?? DEFAULT_GAME_MODE
-            );
+          if (action.redirect) {
+            router.push(action.redirect);
+            return;
           }
-        });
+
+          if (action.showPasswordPrompt) {
+            requestPassword(game.settings.password!, t).then((val) => {
+              if (val.isConfirmed) {
+                flagEnter.current = true;
+                setHasEnteredPassword(true);
+                router.replace(`/game/${gameID}`);
+                metricCounter("room_join_attempts", undefined, {
+                  room_id: gameID,
+                  is_host: "0"
+                });
+                addNewUserToDB(game);
+              } else {
+                router.push("/");
+              }
+            });
+          } else if (action.addUser) {
+            flagEnter.current = true;
+
+            if (action.metricEvent) {
+              metricCounter(
+                action.metricEvent.name,
+                undefined,
+                action.metricEvent.tags
+              );
+            }
+
+            if (query.get("pwd")) {
+              router.replace(`/game/${gameID}`);
+            }
+            addNewUserToDB(game);
+          }
+        } catch (err) {
+          breadcrumb("error", "snapshot_processing_error", {
+            gameID,
+            error: err
+          });
+
+          throw err;
+        } finally {
+          reportApplyStateTime(
+            performance.now() - startApply,
+            gameID,
+            parsedIsHost,
+            game.gameMode ?? DEFAULT_GAME_MODE
+          );
+        }
       });
+    };
+
+    try {
+      unsubscribeRoom = onValue(ref(db, `games/${gameID}/`), (snapshot) => {
+        applyRoomSnapshot(snapshot.val() as RawRoomSnapshot, latestSignalRaw);
+      });
+
+      unsubscribeSignals = onValue(
+        ref(db, `roomHostDisconnects/${gameID}`),
+        (snapshot: DataSnapshot) => {
+          applyRoomSnapshot(
+            latestRoomRaw,
+            snapshot.val() as DisconnectSignalMap
+          );
+        }
+      );
     } catch (err) {
       console.error(err);
       setError(err as Error);
@@ -269,11 +478,30 @@ export const useRoomGame = (): UseRoomGameReturn => {
 
     return () => {
       clearStaleHostRemoval();
+      stopHostHeartbeat();
       breadcrumb("lifecycle", "unsubscribe_onValue");
-      if (unsubscribe) unsubscribe();
+      unsubscribeRoom?.();
+      unsubscribeSignals?.();
       resetContext();
     };
-  }, [isAuthenticated, gUser?.uid, gameID]);
+  }, [
+    db,
+    gameID,
+    gUser?.uid,
+    hasEnteredPassword,
+    isAuthenticated,
+    query,
+    resetContext,
+    router,
+    setGame,
+    setHasEnteredPassword,
+    setIsHost,
+    setLocalUser,
+    setNewUser,
+    stopHostHeartbeat,
+    t,
+    getOrCreateHostSessionId
+  ]);
 
   const addNewUserToDB = (game: Game) => {
     if (gUser?.uid) {
@@ -337,15 +565,43 @@ export const useRoomGame = (): UseRoomGameReturn => {
 
     const roomRef = ref(db, roomPath);
     const removeRoom = localIsHost
-      ? onDisconnect(roomRef)
-          .cancel()
-          .then(() => remove(roomRef))
+      ? (() => {
+          const ownerId = gUser?.uid;
+          const sessionId =
+            ownerId && gameKey
+              ? getOrCreateHostSessionId(gameKey, ownerId)
+              : null;
+
+          stopHostHeartbeat();
+
+          return onDisconnect(roomRef)
+            .cancel()
+            .then(async () => {
+              if (sessionId) {
+                await clearHostDisconnectSignal(db, gameKey, sessionId).catch(
+                  console.error
+                );
+              }
+
+              await remove(roomRef);
+              await remove(ref(db, `roomHostDisconnects/${gameKey}`));
+            });
+        })()
       : remove(roomRef);
 
     removeRoom.catch(console.error).finally(() => {
       router.push("/");
     });
-  }, [currentGame.key, db, gameUser?.username, gUser?.uid, isHost, router]);
+  }, [
+    currentGame.key,
+    db,
+    gameUser?.username,
+    gUser?.uid,
+    getOrCreateHostSessionId,
+    isHost,
+    router,
+    stopHostHeartbeat
+  ]);
 
   const handleInvite = () => {
     handleInviteUtil(isMobileDevice, t, currentGame?.settings.password);

--- a/interfaces/Game.ts
+++ b/interfaces/Game.ts
@@ -7,7 +7,42 @@ import {Timestamp} from "firebase/firestore";
 import {ReactionSession} from "./ReactionBattle";
 
 export type Game = ExternalGame & {
+  hostLease?: HostLease | null;
+  hostConnectionId?: string;
+  hostDisconnectedAt?: number | null;
   reactionSession?: ReactionSession | null;
+};
+
+export type HostLease = {
+  ownerId: string;
+  sessionId: string;
+  claimedAt: number;
+  lastRenewedAt: number;
+};
+
+export type HostDisconnectSignal = {
+  disconnectedAt: number;
+};
+
+export type RoomLifecycleSnapshot = {
+  created?: unknown;
+  hostLease?: unknown;
+  hostDisconnectSignal?: unknown;
+  hostConnectionId?: unknown;
+  hostDisconnectedAt?: unknown;
+  ownerUser?: {
+    key?: unknown;
+  };
+};
+
+export type RawRoomLifecycleSnapshot = {
+  created?: unknown;
+  hostLease?: unknown;
+  hostConnectionId?: unknown;
+  hostDisconnectedAt?: unknown;
+  ownerUser?: {
+    key?: unknown;
+  };
 };
 
 export type RoomUser = Pick<

--- a/lib/game/hostLease.ts
+++ b/lib/game/hostLease.ts
@@ -1,0 +1,148 @@
+import {
+  Database,
+  ref,
+  runTransaction,
+  serverTimestamp,
+  update
+} from "firebase/database";
+
+import {HostLease, RawRoomLifecycleSnapshot} from "interfaces";
+
+export const HOST_LEASE_HEARTBEAT_MS = 20 * 1000;
+export const HOST_LEASE_EXPIRY_MS = 90 * 1000;
+
+const randomToken = () => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+export const createHostSessionId = (ownerId: string) =>
+  `${ownerId}-${randomToken()}`;
+
+export const buildInitialHostLease = (
+  ownerId: string,
+  sessionId: string
+): Omit<HostLease, "claimedAt" | "lastRenewedAt"> & {
+  claimedAt: ReturnType<typeof serverTimestamp>;
+  lastRenewedAt: ReturnType<typeof serverTimestamp>;
+} => ({
+  ownerId,
+  sessionId,
+  claimedAt: serverTimestamp(),
+  lastRenewedAt: serverTimestamp()
+});
+
+export const getHostLeasePath = (roomId: string) => `games/${roomId}/hostLease`;
+
+export const getHostDisconnectSignalPath = (
+  roomId: string,
+  sessionId: string
+) => `roomHostDisconnects/${roomId}/${sessionId}`;
+
+const isHostLease = (value: unknown): value is HostLease => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<HostLease>;
+
+  return (
+    typeof candidate.ownerId === "string" &&
+    candidate.ownerId.length > 0 &&
+    typeof candidate.sessionId === "string" &&
+    candidate.sessionId.length > 0 &&
+    typeof candidate.claimedAt === "number" &&
+    Number.isFinite(candidate.claimedAt) &&
+    typeof candidate.lastRenewedAt === "number" &&
+    Number.isFinite(candidate.lastRenewedAt)
+  );
+};
+
+export const renewHostLease = async (
+  db: Database,
+  roomId: string,
+  ownerId: string,
+  sessionId: string
+) =>
+  runTransaction(
+    ref(db, getHostLeasePath(roomId)),
+    (current: HostLease | null) => {
+      if (!isHostLease(current)) {
+        return;
+      }
+
+      if (current.ownerId !== ownerId || current.sessionId !== sessionId) {
+        return;
+      }
+
+      return {
+        ...current,
+        lastRenewedAt: serverTimestamp()
+      };
+    },
+    {applyLocally: false}
+  );
+
+export const clearHostDisconnectSignal = async (
+  db: Database,
+  roomId: string,
+  sessionId: string
+) =>
+  update(ref(db), {
+    [getHostDisconnectSignalPath(roomId, sessionId)]: null
+  });
+
+export const bootstrapLegacyHostLease = async (
+  db: Database,
+  roomId: string,
+  ownerId: string,
+  sessionId: string
+) =>
+  runTransaction(
+    ref(db, `games/${roomId}`),
+    (currentRoom: RawRoomLifecycleSnapshot | null) => {
+      if (!currentRoom || currentRoom.hostLease) {
+        return;
+      }
+
+      if (currentRoom.ownerUser?.key !== ownerId) {
+        return;
+      }
+
+      return {
+        ...currentRoom,
+        hostLease: buildInitialHostLease(ownerId, sessionId)
+      };
+    },
+    {applyLocally: false}
+  );
+
+export const replaceHostLeaseSession = async (
+  db: Database,
+  roomId: string,
+  ownerId: string,
+  sessionId: string
+) =>
+  runTransaction(
+    ref(db, getHostLeasePath(roomId)),
+    (current: HostLease | null) => {
+      if (!isHostLease(current)) {
+        return;
+      }
+
+      if (current.ownerId !== ownerId || current.sessionId === sessionId) {
+        return;
+      }
+
+      return {
+        ...current,
+        sessionId,
+        claimedAt: serverTimestamp(),
+        lastRenewedAt: serverTimestamp()
+      };
+    },
+    {applyLocally: false}
+  );

--- a/lib/game/hostPresence.ts
+++ b/lib/game/hostPresence.ts
@@ -1,10 +1,223 @@
+import {HOST_LEASE_EXPIRY_MS} from "./hostLease";
+
 export const HOST_DISCONNECT_GRACE_MS = 30 * 1000;
+export const LEGACY_ROOM_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+export type RoomLifecycleState = "active" | "pending" | "stale" | "unknown";
+
+export type RoomLifecycleReason =
+  | "lease-active"
+  | "disconnect-grace"
+  | "host-disconnected"
+  | "lease-expired"
+  | "legacy-age"
+  | "insufficient-evidence";
+
+export type RoomLifecycleAssessment = {
+  cleanupAt: number | null;
+  expectedSessionId: string | null;
+  mayDelete: boolean;
+  observedDisconnectedAt: number | null;
+  reason: RoomLifecycleReason;
+  state: RoomLifecycleState;
+};
+
+type RoomPresenceSnapshot = {
+  created?: unknown;
+  hostConnectionId?: unknown;
+  hostDisconnectedAt?: unknown;
+  hostDisconnectSignal?: unknown;
+  hostLease?: unknown;
+};
+
+type HostLease = {
+  ownerId: string;
+  sessionId: string;
+  claimedAt: number;
+  lastRenewedAt: number;
+};
+
+type HostDisconnectSignal = {
+  disconnectedAt: number;
+};
+
+const isFiniteTimestamp = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0;
+
+const hasHostConnection = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+
+const isHostLease = (value: unknown): value is HostLease => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<HostLease>;
+
+  return (
+    typeof candidate.ownerId === "string" &&
+    candidate.ownerId.trim().length > 0 &&
+    typeof candidate.sessionId === "string" &&
+    candidate.sessionId.trim().length > 0 &&
+    isFiniteTimestamp(candidate.claimedAt) &&
+    isFiniteTimestamp(candidate.lastRenewedAt)
+  );
+};
+
+const isHostDisconnectSignal = (
+  value: unknown
+): value is HostDisconnectSignal => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<HostDisconnectSignal>;
+
+  return isFiniteTimestamp(candidate.disconnectedAt);
+};
+
+export const assessRoomLifecycle = (
+  room: RoomPresenceSnapshot,
+  now = Date.now()
+): RoomLifecycleAssessment => {
+  const lease = isHostLease(room.hostLease) ? room.hostLease : null;
+  const matchingDisconnectSignal = isHostDisconnectSignal(
+    room.hostDisconnectSignal
+  )
+    ? room.hostDisconnectSignal
+    : null;
+
+  if (lease) {
+    const leaseCleanupAt = lease.lastRenewedAt + HOST_LEASE_EXPIRY_MS;
+    const signalDisconnectAt = matchingDisconnectSignal?.disconnectedAt ?? null;
+
+    if (
+      signalDisconnectAt !== null &&
+      signalDisconnectAt >= lease.lastRenewedAt
+    ) {
+      const cleanupAt = signalDisconnectAt + HOST_DISCONNECT_GRACE_MS;
+
+      if (now < cleanupAt) {
+        return {
+          cleanupAt,
+          expectedSessionId: lease.sessionId,
+          mayDelete: false,
+          observedDisconnectedAt: signalDisconnectAt,
+          reason: "disconnect-grace",
+          state: "pending"
+        };
+      }
+
+      return {
+        cleanupAt: null,
+        expectedSessionId: lease.sessionId,
+        mayDelete: true,
+        observedDisconnectedAt: signalDisconnectAt,
+        reason: "host-disconnected",
+        state: "stale"
+      };
+    }
+
+    if (now < leaseCleanupAt) {
+      return {
+        cleanupAt: leaseCleanupAt,
+        expectedSessionId: lease.sessionId,
+        mayDelete: false,
+        observedDisconnectedAt: null,
+        reason: "lease-active",
+        state: "active"
+      };
+    }
+
+    return {
+      cleanupAt: null,
+      expectedSessionId: lease.sessionId,
+      mayDelete: true,
+      observedDisconnectedAt: null,
+      reason: "lease-expired",
+      state: "stale"
+    };
+  }
+
+  if (isFiniteTimestamp(room.hostDisconnectedAt)) {
+    const cleanupAt = room.hostDisconnectedAt + HOST_DISCONNECT_GRACE_MS;
+
+    if (now < cleanupAt) {
+      return {
+        cleanupAt,
+        expectedSessionId: null,
+        mayDelete: false,
+        observedDisconnectedAt: room.hostDisconnectedAt,
+        reason: "disconnect-grace",
+        state: "pending"
+      };
+    }
+
+    return {
+      cleanupAt: null,
+      expectedSessionId: null,
+      mayDelete: true,
+      observedDisconnectedAt: room.hostDisconnectedAt,
+      reason: "host-disconnected",
+      state: "stale"
+    };
+  }
+
+  const hasLegacyDisconnectEvidence =
+    room.hostDisconnectedAt !== null && room.hostDisconnectedAt !== undefined;
+
+  if (!hasLegacyDisconnectEvidence && isFiniteTimestamp(room.created)) {
+    const cleanupAt = room.created + LEGACY_ROOM_MAX_AGE_MS;
+
+    if (now >= cleanupAt) {
+      return {
+        cleanupAt: null,
+        expectedSessionId: null,
+        mayDelete: true,
+        observedDisconnectedAt: null,
+        reason: "legacy-age",
+        state: "stale"
+      };
+    }
+
+    return {
+      cleanupAt,
+      expectedSessionId: null,
+      mayDelete: false,
+      observedDisconnectedAt: null,
+      reason: "insufficient-evidence",
+      state: "unknown"
+    };
+  }
+
+  if (hasHostConnection(room.hostConnectionId)) {
+    return {
+      cleanupAt: isFiniteTimestamp(room.created)
+        ? room.created + LEGACY_ROOM_MAX_AGE_MS
+        : null,
+      expectedSessionId: null,
+      mayDelete: false,
+      observedDisconnectedAt: null,
+      reason: "insufficient-evidence",
+      state: "unknown"
+    };
+  }
+
+  return {
+    cleanupAt: null,
+    expectedSessionId: null,
+    mayDelete: false,
+    observedDisconnectedAt: null,
+    reason: "insufficient-evidence",
+    state: "unknown"
+  };
+};
 
 export const getHostDisconnectRemovalDelay = (
   hostDisconnectedAt?: unknown,
   now = Date.now()
 ) => {
-  if (typeof hostDisconnectedAt !== "number") {
+  if (!isFiniteTimestamp(hostDisconnectedAt)) {
     return null;
   }
 

--- a/lib/game/processSnapshot.ts
+++ b/lib/game/processSnapshot.ts
@@ -2,7 +2,6 @@ import {
   ParsedGameSnapshot,
   parseGameSnapshot
 } from "@leandrolescano/click-battle-core";
-import {DataSnapshot} from "firebase/database";
 
 import {breadcrumb, breadcrumbOnce, withSpanMin} from "observability/sentry";
 
@@ -14,7 +13,7 @@ interface ProcessSnapshotResult {
 }
 
 export const processSnapshot = (
-  raw: DataSnapshot,
+  raw: unknown,
   key: string | null,
   uid: string | undefined,
   gameID: string

--- a/lib/game/roomCleanup.ts
+++ b/lib/game/roomCleanup.ts
@@ -1,0 +1,128 @@
+import {Database, ref, remove, runTransaction} from "firebase/database";
+
+import {HostDisconnectSignal, RoomLifecycleSnapshot} from "interfaces";
+
+import {assessRoomLifecycle} from "./hostPresence";
+
+export type RoomSnapshotEntry<T extends RoomLifecycleSnapshot> = [string, T];
+
+export type RoomSnapshotPartition<T extends RoomLifecycleSnapshot> = {
+  nextEvaluationAt: number | null;
+  staleRoomKeys: string[];
+  visibleEntries: RoomSnapshotEntry<T>[];
+};
+
+export const partitionRoomSnapshots = <T extends RoomLifecycleSnapshot>(
+  rooms: Record<string, T> | null,
+  disconnectSignals: Record<
+    string,
+    Record<string, HostDisconnectSignal>
+  > | null,
+  now: number
+): RoomSnapshotPartition<T> => {
+  const result: RoomSnapshotPartition<T> = {
+    nextEvaluationAt: null,
+    staleRoomKeys: [],
+    visibleEntries: []
+  };
+
+  if (!rooms) {
+    return result;
+  }
+
+  Object.entries(rooms).forEach(([key, room]) => {
+    const sessionId =
+      room.hostLease &&
+      typeof room.hostLease === "object" &&
+      typeof (room.hostLease as {sessionId?: unknown}).sessionId === "string"
+        ? (room.hostLease as {sessionId: string}).sessionId
+        : null;
+    const assessment = assessRoomLifecycle(
+      {
+        ...room,
+        hostDisconnectSignal: sessionId
+          ? disconnectSignals?.[key]?.[sessionId] ?? null
+          : null
+      },
+      now
+    );
+
+    if (assessment.mayDelete) {
+      result.staleRoomKeys.push(key);
+      return;
+    }
+
+    result.visibleEntries.push([key, room]);
+
+    if (
+      assessment.cleanupAt !== null &&
+      (result.nextEvaluationAt === null ||
+        assessment.cleanupAt < result.nextEvaluationAt)
+    ) {
+      result.nextEvaluationAt = assessment.cleanupAt;
+    }
+  });
+
+  return result;
+};
+
+export const deleteRoomIfStillStale = async (
+  db: Database,
+  roomKey: string,
+  getServerNow: () => number,
+  options?: {
+    expectedSessionId?: string | null;
+    observedDisconnectedAt?: number | null;
+  }
+) => {
+  const result = await runTransaction(
+    ref(db, `games/${roomKey}`),
+    (currentRoom: RoomLifecycleSnapshot | null) => {
+      if (!currentRoom) {
+        return;
+      }
+
+      const assessment = assessRoomLifecycle(
+        {
+          ...currentRoom,
+          hostDisconnectSignal:
+            options?.observedDisconnectedAt !== null &&
+            options?.observedDisconnectedAt !== undefined
+              ? {
+                  disconnectedAt: options.observedDisconnectedAt
+                }
+              : null
+        },
+        getServerNow()
+      );
+
+      if (!assessment.mayDelete) {
+        return;
+      }
+
+      if (
+        options?.expectedSessionId &&
+        assessment.expectedSessionId !== options.expectedSessionId
+      ) {
+        return;
+      }
+
+      if (
+        options?.observedDisconnectedAt !== null &&
+        options?.observedDisconnectedAt !== undefined &&
+        assessment.observedDisconnectedAt !== options.observedDisconnectedAt
+      ) {
+        return;
+      }
+
+      return null;
+    },
+    {applyLocally: false}
+  );
+
+  if (result.committed) {
+    remove(ref(db, `roomHostDisconnects/${roomKey}`)).catch(console.error);
+  }
+
+  return result.committed;
+};

--- a/scripts/verify-room-cleanup-rules.mjs
+++ b/scripts/verify-room-cleanup-rules.mjs
@@ -1,0 +1,130 @@
+const EMULATOR_HOST = process.env.RTDB_EMULATOR_HOST ?? "127.0.0.1";
+const EMULATOR_PORT = Number(process.env.RTDB_EMULATOR_PORT ?? "9001");
+const AUTH_EMULATOR_PORT = Number(process.env.AUTH_EMULATOR_PORT ?? "9098");
+const PROJECT_ID = process.env.RTDB_PROJECT_ID ?? "click-battle-rules-check";
+const DB_NAMESPACE = process.env.RTDB_NAMESPACE ?? `${PROJECT_ID}-default-rtdb`;
+
+const TEST_ROOM_ID = "room-cleanup-rules-check";
+const TEST_SESSION_ID = "session-check";
+
+const hostLeasePath = `games/${TEST_ROOM_ID}/hostLease`;
+const disconnectSignalPath = `roomHostDisconnects/${TEST_ROOM_ID}/${TEST_SESSION_ID}`;
+
+const withTimeout = async (promise, label, ms = 10_000) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ms);
+
+  try {
+    return await promise(controller.signal);
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const buildDbUrl = (path, idToken) => {
+  const url = new URL(`http://${EMULATOR_HOST}:${EMULATOR_PORT}/${path}.json`);
+  url.searchParams.set("ns", DB_NAMESPACE);
+
+  if (idToken) {
+    url.searchParams.set("auth", idToken);
+  }
+
+  return url.toString();
+};
+
+const getAnonymousIdToken = async () => {
+  const url = `http://${EMULATOR_HOST}:${AUTH_EMULATOR_PORT}/identitytoolkit.googleapis.com/v1/accounts:signUp?key=demo-api-key`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({returnSecureToken: true})
+  });
+
+  if (!response.ok) {
+    throw new Error(`auth-signup-failed:${response.status}`);
+  }
+
+  const payload = await response.json();
+
+  if (typeof payload.idToken !== "string" || payload.idToken.length === 0) {
+    throw new Error("auth-signup-missing-token");
+  }
+
+  return payload.idToken;
+};
+
+const attempt = async (label, method, path, idToken, body) => {
+  try {
+    const response = await withTimeout(
+      (signal) =>
+        fetch(buildDbUrl(path, idToken), {
+          method,
+          headers: body ? {"Content-Type": "application/json"} : undefined,
+          body: body ? JSON.stringify(body) : undefined,
+          signal
+        }),
+      label
+    );
+
+    return {
+      label,
+      allowed: response.ok,
+      code: response.ok ? null : `${response.status}`
+    };
+  } catch (error) {
+    return {
+      label,
+      allowed: false,
+      code: error instanceof Error ? error.message : "unknown"
+    };
+  }
+};
+
+const verifyMode = async (idToken) => ({
+  results: await Promise.all([
+    attempt("read hostLease", "GET", hostLeasePath, idToken),
+    attempt("write hostLease", "PUT", hostLeasePath, idToken, {
+      ownerId: "owner-check",
+      sessionId: TEST_SESSION_ID,
+      claimedAt: Date.now(),
+      lastRenewedAt: Date.now()
+    }),
+    attempt("delete hostLease", "DELETE", hostLeasePath, idToken),
+    attempt("read disconnect signal", "GET", disconnectSignalPath, idToken),
+    attempt("write disconnect signal", "PUT", disconnectSignalPath, idToken, {
+      disconnectedAt: Date.now()
+    }),
+    attempt("delete disconnect signal", "DELETE", disconnectSignalPath, idToken)
+  ])
+});
+
+const anonymousToken = await getAnonymousIdToken();
+const unauthenticated = await verifyMode(null);
+const authenticated = await verifyMode(anonymousToken);
+
+console.log(
+  JSON.stringify(
+    {
+      emulatorHost: EMULATOR_HOST,
+      emulatorPort: EMULATOR_PORT,
+      authEmulatorPort: AUTH_EMULATOR_PORT,
+      projectId: PROJECT_ID,
+      namespace: DB_NAMESPACE,
+      unauthenticated,
+      authenticated
+    },
+    null,
+    2
+  )
+);
+
+const unauthenticatedDenied = unauthenticated.results.every(
+  (result) => !result.allowed
+);
+const authenticatedAllowed = authenticated.results.every(
+  (result) => result.allowed
+);
+
+if (!unauthenticatedDenied || !authenticatedAllowed) {
+  process.exitCode = 1;
+}

--- a/specs/002-cleanup-ghost-rooms/checklists/presence-resilience.md
+++ b/specs/002-cleanup-ghost-rooms/checklists/presence-resilience.md
@@ -1,0 +1,58 @@
+# Presence Resilience Requirements Checklist: Automatic Ghost Room Cleanup
+
+**Purpose**: Assess whether the requirements can reliably distinguish a live host from an orphaned room when `onDisconnect` is missing, delayed, or leaves stale presence evidence.
+**Created**: 2026-06-24
+**Feature**: [Automatic Ghost Room Cleanup](../spec.md)
+
+**Note**: This checklist evaluates the quality and completeness of the written requirements, not the current implementation.
+
+## Requirement Completeness
+
+- [ ] CHK001 Does the specification define how host availability remains current when `onDisconnect` registration fails or never produces a disconnect timestamp? [Gap, Spec §FR-001]
+- [ ] CHK002 Are requirements defined for distinguishing a current `hostConnectionId` from an abandoned identifier left by a dead browser connection? [Gap, Spec §FR-001, §FR-010]
+- [ ] CHK003 Does the specification require a bounded freshness signal, such as a host lease or last-seen timestamp, for rooms that contain apparently valid presence metadata? [Gap, Spec §FR-001]
+- [ ] CHK004 Are lifecycle requirements documented for presence setup failing before the game screen finishes opening? [Completeness, Spec §Edge Cases]
+- [ ] CHK005 Are the required persisted fields and their authoritative meanings documented for active, pending, stale, and unknown host-presence states? [Completeness, Spec §Key Entities]
+
+## Requirement Clarity
+
+- [ ] CHK006 Is “enough current host-availability information” defined with objective freshness and validity criteria? [Ambiguity, Spec §FR-001]
+- [ ] CHK007 Is “currently available host” defined independently of merely having a non-empty connection identifier? [Ambiguity, Spec §FR-010, §FR-012]
+- [ ] CHK008 Is the starting event for the 30-second reconnect grace period unambiguous when no reliable disconnect event exists? [Ambiguity, Spec §FR-003]
+- [ ] CHK009 Is the maximum allowed age of host-availability evidence quantified for both foreground and background browser states? [Gap, Spec §FR-001]
+- [ ] CHK010 Is the meaning of “usable host-presence evidence” precise enough to classify stale, malformed, missing, and contradictory values consistently? [Ambiguity, Spec §FR-011, §FR-012]
+
+## Requirement Consistency
+
+- [ ] CHK011 Do active-room preservation requirements remain consistent with cleanup requirements when a stale connection identifier exists but no host is reachable? [Conflict, Spec §FR-010, §FR-011]
+- [ ] CHK012 Does the 24-hour fallback align with FR-001, or is it explicitly limited to records with no presence fields while stale-looking presence records follow another bounded rule? [Consistency, Spec §FR-001, §FR-011]
+- [ ] CHK013 Are “no polling traffic” and “no continuously running cleanup process” reconciled with any requirement to keep host freshness evidence current? [Conflict, Plan §Performance Goals, Spec §FR-015]
+- [ ] CHK014 Are direct-link and room-list classifications required to use the same definition of host freshness and the same time source? [Consistency, Spec §FR-005, §FR-007, §FR-009]
+
+## Acceptance Criteria Quality
+
+- [ ] CHK015 Can acceptance testing objectively prove that a room with a stale `hostConnectionId` and no disconnect timestamp becomes non-joinable within a bounded time? [Measurability, Spec §SC-001, Gap]
+- [ ] CHK016 Does SC-003 define what constitutes a “valid available host” rather than assuming the presence marker is truthful? [Ambiguity, Spec §SC-003]
+- [ ] CHK017 Are measurable false-positive limits defined for active hosts affected by delayed timers, background-tab throttling, temporary offline periods, or device sleep? [Gap, Spec §SC-002, §SC-003]
+- [ ] CHK018 Is the maximum cleanup delay specified separately for disconnects reported normally and failures where no disconnect evidence is recorded? [Gap, Spec §SC-001, §SC-004]
+
+## Recovery and Exception Coverage
+
+- [ ] CHK019 Are recovery requirements defined when the host refreshes its availability immediately before or during a guarded cleanup decision? [Coverage, Spec §FR-004, §FR-013]
+- [ ] CHK020 Are requirements defined for write failures while renewing host freshness, including whether the room becomes pending, unknown, or preserved? [Gap, Spec §FR-014]
+- [ ] CHK021 Are contradictory snapshots—fresh host evidence plus an expired disconnect timestamp—assigned an explicit precedence rule? [Gap, Spec §FR-004, §FR-010]
+- [ ] CHK022 Are clock skew, delayed server timestamps, and missing server-time offset requirements addressed for every expiration threshold? [Coverage, Gap]
+- [ ] CHK023 Is behavior specified when no user evaluates the room list after host freshness expires, including the accepted persistence duration in storage? [Clarity, Spec §User Story 1 Scenario 2, §Assumptions]
+
+## Dependencies and Scope Boundaries
+
+- [ ] CHK024 Is Firebase’s `onDisconnect` delivery/registration behavior documented as an assumption rather than treated as guaranteed host liveness? [Assumption, Spec §FR-001]
+- [ ] CHK025 Is the exclusion of multiple simultaneous host tabs reconciled with reconnects that briefly overlap old and new connection identifiers? [Scope, Spec §Assumptions]
+- [ ] CHK026 Are heartbeat or lease write-frequency, bandwidth, and battery constraints specified if bounded host freshness is required without backend jobs? [Non-Functional, Gap]
+- [ ] CHK027 Is the obsolete `/legacy` UI explicitly excluded while old room records encountered through current `/` and `/game/{gameId}` flows remain covered? [Consistency, Spec §Assumptions, Plan §Scale/Scope]
+
+## Notes
+
+- Check items off as completed: `[x]`.
+- Record requirement amendments or unresolved decisions inline.
+- Items intentionally focus on specification quality; implementation verification belongs in the feature test plan.

--- a/specs/002-cleanup-ghost-rooms/checklists/requirements.md
+++ b/specs/002-cleanup-ghost-rooms/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Automatic Ghost Room Cleanup
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation iteration 1: all items passed.
+- Validation iteration 2: all items passed after replacing scheduled/always-on cleanup with room-list-triggered filtering and background deletion.
+- The user's Firebase reference is retained only in the source description; requirements describe the product outcome without prescribing implementation.
+- Reasonable defaults are documented for the 30-second reconnect grace period, the 24-hour legacy fallback threshold, opportunistic cleanup, and no host transfer.

--- a/specs/002-cleanup-ghost-rooms/contracts/room-cleanup-contract.md
+++ b/specs/002-cleanup-ghost-rooms/contracts/room-cleanup-contract.md
@@ -1,0 +1,111 @@
+# Contract: Lease-Based Opportunistic Room Cleanup
+
+## Scope
+
+This contract governs host-session registration, heartbeat renewal, disconnect signaling, room classification, display, and guarded deletion without a scheduled job or host takeover.
+
+## Persisted Contract
+
+Modern rooms contain:
+
+```text
+games/{gameId}/hostLease {
+  ownerId: string,
+  sessionId: string,
+  claimedAt: server timestamp,
+  lastRenewedAt: server timestamp
+}
+```
+
+Reliable disconnect callbacks write outside the active room:
+
+```text
+roomHostDisconnects/{gameId}/{sessionId} {
+  disconnectedAt: server timestamp
+}
+```
+
+`hostConnectionId` and inline `hostDisconnectedAt` remain readable compatibility fields but are not sufficient to prove a modern host is alive.
+
+## Host Session Contract
+
+1. A new room is created with its initial host lease in the same atomic root update.
+2. A returning owner may replace the current session only while the room and current lease still exist and ownership matches.
+3. A legacy room without a lease may be bootstrapped once through a guarded whole-room transaction.
+4. No session registration, renewal, or delayed callback may recreate an absent `games/{gameId}` record.
+5. Ownership is never transferred to a guest.
+
+## Heartbeat Contract
+
+1. The current host attempts renewal every 20 seconds.
+2. Renewal transacts only at `games/{gameId}/hostLease`.
+3. It commits a server timestamp only if `ownerId` and `sessionId` equal the caller's current host session.
+4. A null, missing, deleted, or mismatched lease aborts and stops that heartbeat loop.
+5. After 90 seconds without a committed renewal, the lease is stale immediately; no additional grace applies.
+6. Background throttling, device sleep, and browser suspension do not extend the 90-second deadline.
+
+## Disconnect Contract
+
+1. `onDisconnect` writes `disconnectedAt` under the exact session's sibling signal path.
+2. Only a signal matching the room's current `hostLease.sessionId` participates in classification.
+3. A matching signal starts the existing 30-second reconnect grace.
+4. A later committed renewal for that same session supersedes the signal; signal removal ordering is not destructive authority.
+5. Signals for replaced sessions are ignored and cleaned best-effort.
+
+## Classification Contract
+
+Given room `room`, matching disconnect signal `signal`, and server-aligned `now`:
+
+| Condition | State | Visible | Delete requested | Next reevaluation |
+|---|---|---|---|---|
+| Valid lease, `lastRenewedAt > signal.disconnectedAt` or no matching signal, and age `< 90s` | active | Yes | No | At lease deadline |
+| Matching signal is newer than renewal and age `< 30s` | pending | Yes | No | At disconnect deadline |
+| Matching signal is newer than renewal and age `>= 30s` | stale disconnect | No | Yes | None |
+| Lease renewal age `>= 90s` | stale lease | No | Yes | None |
+| No usable lease/current signal and room age `>= 24h` | stale legacy | No | Yes | None |
+| No usable evidence and room age `< 24h` | unknown legacy | Yes if parseable | No | At 24-hour boundary |
+| Malformed or contradictory evidence without a positive stale rule | unknown | Yes if parseable | No | None |
+
+The classifier is pure and shared by current `/` and `/game/{gameId}` flows. `/legacy` is excluded.
+
+## Room List Contract
+
+1. Subscribe to current rooms and session-scoped disconnect signals.
+2. Retain the latest value from both sources and evaluate a consistent in-memory pair whenever either changes.
+3. Estimate server time through the existing server-time offset.
+4. Partition before committing visible list state.
+5. Start guarded deletion for stale rooms without blocking rendering.
+6. Maintain one cancellable timeout for the earliest disconnect, lease, or legacy deadline.
+7. Clear listeners and the timeout on unmount.
+
+No viewer polling interval, scheduled job, backend endpoint, or continuously running cleanup service is allowed.
+
+## Guarded Deletion Contract
+
+Input: database, room key, lifecycle evidence, server-aligned time provider.
+
+1. Transact at `games/{gameId}`.
+2. Abort if the room is absent, malformed, active, pending, recovered, or references a newer/different host session.
+3. For lease expiry, recheck current `hostLease.lastRenewedAt + 90s`.
+4. For disconnect expiry, require the expected session and abort if current `lastRenewedAt > observedDisconnectedAt`.
+5. Return `null` only for positive current stale evidence.
+6. After a committed deletion, remove `roomHostDisconnects/{gameId}` best-effort.
+7. Never create, mutate, or delete Firestore room history.
+
+Concurrent cleanup attempts are idempotent. Network/permission failures leave the room eligible for later reevaluation while stale rooms remain hidden.
+
+## Direct-Room Contract
+
+- A stale direct-room snapshot cannot add a visitor.
+- The direct-room flow consumes the same current-session disconnect evidence and lease classifier.
+- A pending room permits recovery until its deadline.
+- Missing/expired/replaced authority stops the old host heartbeat.
+- When the room snapshot becomes null, all current clients follow the existing unavailable-room fallback.
+
+## Compatibility and Permission Gate
+
+- Applies to classic-speed and Reaction Battle.
+- Existing pre-lease rooms remain readable and receive the 24-hour conservative fallback.
+- A current authenticated owner may bootstrap a legacy room lease; guests may not.
+- Repository `database.rules.json` is not configured by `firebase.json`; deployed-equivalent read/write rules for the new lease and disconnect path must be proven in an explicitly safe environment.
+- This contract does not authorize broad client write/delete grants.

--- a/specs/002-cleanup-ghost-rooms/data-model.md
+++ b/specs/002-cleanup-ghost-rooms/data-model.md
@@ -1,0 +1,90 @@
+# Data Model: Automatic Ghost Room Cleanup
+
+## Active Room
+
+Path: `games/{gameId}` in Firebase Realtime Database.
+
+| Field | Type | Required | Lifecycle meaning |
+|---|---|---|---|
+| `created` | number | Expected | Server timestamp for the conservative 24-hour fallback. |
+| `ownerUser.key` | string | Expected for modern rooms | Auth UID allowed to establish the host session. |
+| `hostLease` | object | Required for new rooms | Authoritative current host session and last committed renewal. |
+| `hostConnectionId` | string | Legacy optional | Compatibility metadata only; never sufficient liveness evidence by itself. |
+| `hostDisconnectedAt` | number or null | Legacy optional | Existing inline disconnect evidence for pre-lease compatibility. New sessions use the separate signal path. |
+| Existing game fields | existing types | Existing contract | Unchanged and irrelevant to lease classification. |
+
+### Embedded Host Lease
+
+Path: `games/{gameId}/hostLease`.
+
+| Field | Type | Required | Validation |
+|---|---|---|---|
+| `ownerId` | string | Yes | Must match `ownerUser.key` when established. |
+| `sessionId` | string | Yes | Unique opaque ID for one host browser session. |
+| `claimedAt` | number | Yes | Server timestamp for session establishment and missing-presence safety. |
+| `lastRenewedAt` | number | Yes | Server timestamp advanced only by the matching current session. |
+
+Validation rules:
+
+- A recurring heartbeat transaction aborts if the lease is absent or either identity differs.
+- Heartbeat never creates a missing lease or room.
+- A returning owner may replace a present lease session; a legacy missing lease requires a one-time guarded room bootstrap.
+- `lastRenewedAt + 90_000` is the final lease deadline. No extra 30-second grace is added.
+- Old `hostConnectionId` values do not override an expired or missing lease.
+
+## Host Disconnect Signal
+
+Path: `roomHostDisconnects/{gameId}/{sessionId}`.
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `disconnectedAt` | number | Yes | Server timestamp written by `onDisconnect` for that exact session. |
+
+Rules:
+
+- Only the entry whose `sessionId` matches the room's current lease can influence room state.
+- A newer committed `lastRenewedAt` for the same session supersedes the signal.
+- A matching signal reaches its deadline at `disconnectedAt + 30_000`.
+- Old or orphaned signals are non-authoritative and may be removed opportunistically.
+- Signal writes cannot recreate `games/{gameId}` because they live outside the active-room path.
+
+## Room Lifecycle Assessment
+
+| Field | Type | Meaning |
+|---|---|---|
+| `state` | `active` \| `pending` \| `stale` \| `unknown` | Whether display and deletion are allowed. |
+| `reason` | `lease-active` \| `disconnect-grace` \| `host-disconnected` \| `lease-expired` \| `legacy-age` \| `insufficient-evidence` | Deterministic classification reason. |
+| `cleanupAt` | number or null | Next server-aligned deadline for one-shot reevaluation. |
+| `mayDelete` | boolean | True only with positive stale evidence. |
+| `expectedSessionId` | string or null | Session guard supplied to destructive cleanup. |
+| `observedDisconnectedAt` | number or null | Signal timestamp used to reject deletion after a newer renewal. |
+
+## State Transitions
+
+```text
+session registered -> lease-active
+lease-active -- matching onDisconnect signal --> disconnect-grace (30s)
+disconnect-grace -- same session renews --> lease-active
+disconnect-grace -- deadline passes --> stale(host-disconnected)
+lease-active -- no committed renewal for 90s --> stale(lease-expired)
+stale -- guarded transaction sees newer renewal/session --> lease-active
+stale -- guarded transaction confirms evidence --> deleted
+
+pre-lease room -- no usable liveness + age reaches 24h --> stale(legacy-age)
+```
+
+## Concurrency and Idempotency
+
+- Renewal transactions touch only `hostLease`, avoiding contention with clicks and other game state.
+- Guarded deletion touches the whole room only when stale cleanup is attempted.
+- A replaced session cannot renew because its identity no longer matches.
+- A delayed disconnect signal cannot affect a newer session.
+- A delayed heartbeat sees a missing/mismatched lease and aborts, so it cannot recreate a deleted room.
+- Concurrent deletion attempts remain idempotent; the first commit removes the room and later attempts abort.
+
+## Retention
+
+- Stale active rooms are removed opportunistically when current clients evaluate them.
+- Disconnect signals are best-effort cleanup metadata and are removed after room deletion or session replacement.
+- Existing Firestore room history is never created, changed, or removed by opportunistic cleanup.
+- The obsolete `/legacy` UI and its code remain untouched.

--- a/specs/002-cleanup-ghost-rooms/permission-validation.md
+++ b/specs/002-cleanup-ghost-rooms/permission-validation.md
@@ -1,0 +1,67 @@
+# Permission Validation: Automatic Ghost Room Cleanup
+
+## Scope
+
+Validate the read/write/delete behavior required by:
+
+- `games/{gameId}/hostLease`
+- `roomHostDisconnects/{gameId}/{sessionId}`
+
+without broadening `database.rules.json` and without running destructive checks against an unsafe Firebase target.
+
+## What was verified locally
+
+### 1. Lifecycle behavior with the existing emulator-backed app
+
+The feature logic was validated end-to-end through authenticated Playwright coverage against the local emulators:
+
+- `tests/e2e/auth.setup.ts --project=setup`
+- `tests/e2e/game.spec.ts --project=chromium --workers=1`
+
+These runs proved the room-lifecycle behavior, but not representative Realtime Database authorization behavior, because the repository's main `firebase.json` does not wire `database.rules.json` into the RTDB emulator configuration.
+
+### 2. Current deployed-equivalent rules on an isolated RTDB emulator
+
+An isolated RTDB emulator was started with:
+
+```powershell
+rtk npx firebase emulators:start --config firebase.rules-check.json --only auth,database --project click-battle-rules-check
+```
+
+That config explicitly points to the repository `database.rules.json`, updated to match the deployed ruleset shared during validation:
+
+- `games/**`: authenticated read/write
+- `roomHostDisconnects/**`: authenticated read/write
+- `gamesList/**`, `users/**`, `config/**`: authenticated read/write
+- everything else: denied
+
+Then the verification script was run:
+
+```powershell
+$env:RTDB_EMULATOR_HOST='127.0.0.1'
+$env:RTDB_EMULATOR_PORT='9001'
+$env:AUTH_EMULATOR_PORT='9098'
+$env:RTDB_PROJECT_ID='click-battle-rules-check'
+node scripts/verify-room-cleanup-rules.mjs
+```
+
+Observed result:
+
+- unauthenticated client:
+  - read/write/delete `games/{gameId}/hostLease` -> denied (`401`)
+  - read/write/delete `roomHostDisconnects/{gameId}/{sessionId}` -> denied (`401`)
+- authenticated client:
+  - read/write/delete `games/{gameId}/hostLease` -> allowed
+  - read/write/delete `roomHostDisconnects/{gameId}/{sessionId}` -> allowed
+
+## Conclusion
+
+The ghost-room cleanup feature's required RTDB paths are compatible with the deployed-equivalent ruleset provided for this project:
+
+- unauthenticated access remains blocked
+- authenticated clients can initialize, renew, read, and delete `hostLease`
+- authenticated clients can write, read, and delete `roomHostDisconnects`
+
+## Remaining caveat
+
+The repository's main `firebase.json` still does not wire `database.rules.json` into the default RTDB emulator startup path, so the isolated harness remains the authoritative local permission check. This is a tooling consistency gap, not a feature-authorization blocker.

--- a/specs/002-cleanup-ghost-rooms/plan.md
+++ b/specs/002-cleanup-ghost-rooms/plan.md
@@ -1,0 +1,124 @@
+# Implementation Plan: Automatic Ghost Room Cleanup
+
+**Branch**: `002-cleanup-ghost-rooms` | **Date**: 2026-06-24 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/002-cleanup-ghost-rooms/spec.md`
+
+## Summary
+
+Extend the existing opportunistic cleanup with a server-timestamped host lease renewed every 20 seconds and expired after 90 seconds. The lease is authoritative even when an old connection marker remains. It is bound to the current host identity and `sessionID`, renewed through a narrow transaction that aborts for missing or replaced sessions, and rechecked by guarded room deletion. Keep the faster 30-second `onDisconnect` path through a session-scoped signal outside `games/{gameId}` so a delayed disconnect callback cannot recreate a deleted active-room record. No host takeover, scheduled job, backend worker, `/legacy` UI change, or cleanup-only history write is introduced.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9.3, React 18.2, Node.js 20-compatible project tooling
+
+**Primary Dependencies**: Next.js 15.5.18 App Router, Firebase 12.13.0 Realtime Database/Auth, `@leandrolescano/click-battle-core` 1.3.x, React i18next, Sentry, Playwright 1.47+
+
+**Storage**: Firebase Realtime Database `games/{gameId}` for active rooms and `roomHostDisconnects/{gameId}/{sessionId}` for session-scoped disconnect signals; Firestore room history remains unchanged
+
+**Testing**: TypeScript check, targeted ESLint, i18n validation, and authenticated Playwright against Firebase Auth/Realtime Database/Firestore emulators
+
+**Target Platform**: Modern desktop and mobile browsers deployed through the existing Vercel-hosted Next.js web app
+
+**Project Type**: Single Next.js web application with client-side realtime room lifecycle handling
+
+**Performance Goals**: One heartbeat transaction every 20 seconds per active host; one nearest-deadline list timer; no polling by viewers; stale rooms hidden before visible state commits; no heartbeat transaction at the whole-room path
+
+**Constraints**: Lease expires at 90 seconds with no extra grace; reliable session-scoped disconnect signals retain the existing 30-second grace; no takeover, cron, Cloud Function schedule, Vercel Cron, queue, backend cleanup service, or continuously running viewer poller; delayed sessions cannot recreate rooms; destructive verification remains emulator-only unless the target is explicitly safe
+
+**Scale/Scope**: Host lease/session registration, heartbeat renewal, disconnect signaling, shared lifecycle classification, guarded deletion, current `/` and `/game/{gameId}` consumers, fixtures/tests, and documentation; obsolete `/legacy` UI, player-host migration, multi-host support, and unrelated room/game state are out of scope
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+- **Production Gameplay Stability**: PASS. The design preserves intentional host exit, the current 30-second reliable-disconnect grace, all game modes, and redirects stale direct links without introducing host migration. The 90-second lease behavior is explicitly specified for suspended or unreachable hosts.
+- **Next.js App Router With Existing Patterns**: PASS. Heartbeat ownership remains in the existing client room hook; classification and Firebase mutation stay in existing `lib/game` modules. The obsolete `/legacy` UI remains untouched.
+- **Firebase-Backed Contract Discipline**: PASS WITH RELEASE GATE. New fields and the disconnect-signal path are documented below. Emulator and deployed-equivalent permission behavior must be validated; `database.rules.json` is not wired through `firebase.json`, so this plan does not guess or broaden production rules.
+- **Verification Before Promotion**: PASS. The design requires authenticated emulator coverage for lease expiry, renewal, session replacement, delayed callbacks, deletion races, direct links, and the existing full game regression suite.
+- **Branched Delivery And Incremental Safety**: PASS. Work remains on `002-cleanup-ghost-rooms` and keeps the lifecycle changes isolated from game rules, history, and `/legacy`.
+
+**Post-design re-check**: PASS. The data model and contracts preserve all gates. Permission verification remains an explicit pre-promotion gate rather than a constitution exception.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-cleanup-ghost-rooms/
+|-- plan.md
+|-- research.md
+|-- data-model.md
+|-- quickstart.md
+|-- contracts/
+|   `-- room-cleanup-contract.md
+|-- checklists/
+|   |-- requirements.md
+|   `-- presence-resilience.md
+`-- tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+components-new/CreateSection/index.tsx  # Initialize room + first host lease atomically
+
+hooks/useRoomGame.ts                    # Register session, heartbeat, onDisconnect signal
+
+lib/game/
+|-- hostPresence.ts                     # Pure lease/disconnect/legacy classification
+|-- roomCleanup.ts                      # Partitioning and guarded room deletion
+|-- hostLease.ts                        # Session registration and conditional renewal helpers
+`-- serverTimeOffset.ts                 # Existing server-aligned client clock
+
+interfaces/Game.ts                      # Lease, session, and disconnect-signal shapes
+
+app/page.tsx                            # Combine room/disconnect snapshots before display
+
+tests/e2e/
+|-- fixtures.ts                         # Seed/renew/expire/replace lease test controls
+`-- game.spec.ts                        # Lease resilience and regression scenarios
+```
+
+**Structure Decision**: Extend the existing single-project room lifecycle. Store the authoritative lease inside each room so guarded deletion can recheck it atomically. Store only `onDisconnect` signals in a separate session-scoped path, preventing delayed callbacks from recreating an active room. Use one small helper for session registration/renewal rather than embedding interval and transaction details throughout `useRoomGame.ts`.
+
+## Design Details
+
+### Session registration
+
+- New room creation generates one `sessionID` and writes the room, initial `hostLease`, and empty disconnect state in one root multi-location update.
+- A returning authenticated owner may replace the current lease session through a conditional transaction. A missing room/lease aborts rather than creating data.
+- A legacy room without `hostLease` may be bootstrapped once through a guarded whole-room transaction that proves the room exists and the authenticated user is its owner. Recurring heartbeat never transacts at the whole-room path.
+
+### Heartbeat lifecycle
+
+- The host renews `games/{gameId}/hostLease` every 20 seconds.
+- Renewal uses `runTransaction`, succeeds only when `ownerId` and `sessionId` still match, and writes `lastRenewedAt` using a server timestamp.
+- Null, deleted, replaced, or mismatched lease values abort. The interval stops when renewal loses authority, the room disappears, or the component unmounts.
+- A failed network write does not advance local authority. Ninety seconds after the last committed renewal, the room is stale.
+
+### Disconnect lifecycle
+
+- `onDisconnect` writes `roomHostDisconnects/{gameId}/{sessionId}/disconnectedAt` instead of mutating `games/{gameId}`.
+- Only a signal matching the room's current lease session participates in classification. Delayed signals from replaced sessions are ignored.
+- A successful renewal clears the matching disconnect signal after the lease timestamp commits. Deletion safety still relies on the room's renewed lease timestamp, not signal removal ordering.
+- Obsolete signal records are removed opportunistically after session replacement or room deletion; they never make a room joinable and cannot recreate `games/{gameId}`.
+
+### Classification precedence
+
+1. A valid current lease renewed within 90 seconds is active unless a matching, later disconnect signal is in its 30-second grace.
+2. A matching disconnect signal is stale after 30 seconds unless the same lease has a later committed renewal.
+3. A current lease older than 90 seconds is stale immediately, with no additional grace, even if `hostConnectionId` remains populated.
+4. A malformed lease is unknown and non-deletable unless an independent conservative legacy-age rule applies.
+5. A room without a usable lease or matching disconnect evidence becomes stale after the existing 24-hour fallback. A legacy `hostConnectionId` alone is not current liveness evidence.
+
+### Guarded deletion
+
+- The transaction remains at `games/{gameId}` and reclassifies the current embedded lease at commit time.
+- For disconnect-triggered cleanup it also verifies that the room still references the expected session and that `lastRenewedAt` was not renewed after the observed disconnect timestamp.
+- Returning `null` deletes only a still-stale room. Recovery, session replacement, ambiguity, or a fresher lease aborts.
+- Disconnect-signal cleanup follows successful room deletion as a best-effort sibling-path removal and never creates Firestore history.
+
+## Complexity Tracking
+
+No constitution violations require justification. The additional disconnect-signal path is the smallest design that preserves the 30-second `onDisconnect` behavior without allowing a delayed callback to recreate or corrupt `games/{gameId}`.

--- a/specs/002-cleanup-ghost-rooms/quickstart.md
+++ b/specs/002-cleanup-ghost-rooms/quickstart.md
@@ -1,0 +1,117 @@
+# Quickstart: Automatic Ghost Room Cleanup
+
+## Safety First
+
+Cleanup tests delete live-room records. Use the local Firebase emulators and confirm the application is connected to them. Do not run destructive room-cleanup scenarios against a Vercel preview, sandbox, development domain, or production until its Firebase target is explicitly confirmed safe.
+
+## Prerequisites
+
+- Install existing project dependencies.
+- Start the Next.js app with the Firebase Auth, Realtime Database, and Firestore emulators.
+- Ensure authenticated Playwright storage states exist before logged-in E2E tests.
+
+## Local Environment
+
+```powershell
+rtk yarn dev:start
+```
+
+In a separate terminal, prepare authenticated players before running game tests:
+
+```powershell
+rtk yarn playwright test --project=setup
+```
+
+## Implementation Order
+
+1. Extend local room types with `hostLease` and session-scoped disconnect-signal shapes.
+2. Add `lib/game/hostLease.ts` for initial session registration, one-time legacy bootstrap, 20-second conditional renewal, and heartbeat shutdown.
+3. Extend `lib/game/hostPresence.ts` and `lib/game/roomCleanup.ts` with 90-second lease classification and session-aware guarded deletion.
+4. Initialize new rooms with their first lease in `components-new/CreateSection/index.tsx`.
+5. Replace inline room `onDisconnect` mutation in `hooks/useRoomGame.ts` with the sibling session signal and start/stop heartbeat ownership there.
+6. Combine room and disconnect-signal snapshots in `app/page.tsx`, retaining one nearest-deadline timer.
+7. Extend emulator fixtures and Playwright coverage before treating the previous implementation validation as current.
+
+## Required E2E Scenarios
+
+- A room already beyond the 30-second disconnect grace is never rendered and is deleted.
+- A room whose deadline is about one second away initially remains eligible, then disappears and is deleted without another Firebase write.
+- A host recovery before the deadline cancels deletion and preserves the room.
+- A room whose lease has not renewed for 90 seconds is hidden and deleted even when an old `hostConnectionId` remains.
+- A lease at 89 seconds remains visible, then expires without another Firebase write or an additional grace period.
+- A matching host session renews every 20 seconds and remains active beyond the original 90-second deadline.
+- A replaced session's delayed heartbeat aborts and cannot extend the current lease.
+- A delayed `onDisconnect` signal from an old session cannot close or alter the current session.
+- A heartbeat after room deletion cannot recreate `games/{gameId}`.
+- A host browser suspended beyond 90 seconds is treated as unavailable.
+- A legacy room older than 24 hours with no presence fields is hidden and deleted.
+- An equally old room opened by its authenticated owner bootstraps a current lease before cleanup, while a comparable room with only stale legacy presence is removed.
+- A failed/aborted guarded deletion is retried by a later list evaluation while the room remains hidden.
+- Old room data without lifecycle fields is cleaned through the current room list.
+- A stale direct link does not add a visitor and follows the existing unavailable-room fallback.
+- Classic-speed and Reaction Battle room creation/join smoke checks continue to pass.
+
+Run the focused tests:
+
+```powershell
+rtk yarn playwright test tests/e2e/game.spec.ts --project=chromium --grep "ghost room|stale room|disconnect grace|host lease|heartbeat|host session"
+```
+
+## Static Verification
+
+```powershell
+rtk yarn check:tsc
+rtk yarn lint:es
+rtk yarn check:i18n
+```
+
+## Permission Verification
+
+Use the isolated RTDB rules harness when you need to prove what the repository rules actually allow:
+
+```powershell
+rtk npx firebase emulators:start --config firebase.rules-check.json --only auth,database --project click-battle-rules-check
+```
+
+In a separate terminal:
+
+```powershell
+$env:RTDB_EMULATOR_HOST='127.0.0.1'
+$env:RTDB_EMULATOR_PORT='9001'
+$env:AUTH_EMULATOR_PORT='9098'
+$env:RTDB_PROJECT_ID='click-battle-rules-check'
+node scripts/verify-room-cleanup-rules.mjs
+```
+
+Expected result with the current deployed-equivalent rules: unauthenticated access is denied, while authenticated access is allowed for all required `hostLease` and `roomHostDisconnects` read/write/delete operations. See [permission-validation.md](permission-validation.md) for the captured findings.
+
+## Manual Verification
+
+1. Create a room in the emulator-backed app and inspect its initial `hostLease` owner, session, and server timestamps.
+2. Observe at least two 20-second renewals for the same session.
+3. Stop renewals without writing a disconnect signal, keep the old connection ID, and open `/` as another authenticated player around the 90-second boundary.
+4. Confirm the room is visible before the boundary, hidden at expiry, and removed without an extra 30-second grace.
+5. Repeat with a matching disconnect signal and confirm the existing 30-second recovery path.
+6. Replace the session, submit a delayed old-session heartbeat/signal, and confirm the new session remains authoritative.
+7. Delete the room, attempt another old heartbeat, and confirm `games/{gameId}` remains absent.
+
+The obsolete `/legacy` UI is intentionally untouched and is not part of manual validation.
+
+## Previous Baseline Validation (Before Host Lease)
+
+- Authenticated Playwright setup passed against the local Firebase emulators (2/2).
+- Focused cleanup coverage passed (10/10), including list filtering, deadline reevaluation, direct-link rejection, host recovery, session replacement, no room recreation after deletion, no cleanup-only Firestore history, and concurrent idempotent deletion.
+- The complete Chromium game regression suite passed (21/21).
+- `check:tsc` and targeted ESLint validation for every touched TypeScript source/test file passed.
+- Repository-wide `lint:es` still reports unrelated pre-existing errors outside the touched files.
+- `check:i18n` still reports 12 unrelated pre-existing ranking translation entries; this feature adds no user-facing copy.
+- `app/legacy/page.tsx`, `firebase.json`, and `database.rules.json` have no feature diff. No cron, scheduled job, backend cleanup service, or security-rule expansion was introduced.
+- The isolated rules harness confirms the deployed-equivalent RTDB ruleset allows the required authenticated lease/disconnect operations while still denying unauthenticated access.
+
+These results validate the first cleanup increment only. Lease/session implementation requires rerunning auth setup, the focused lifecycle scenarios, and the complete Chromium game suite.
+
+## Promotion Verification
+
+- Validate the branch on its Vercel preview only after confirming whether the preview points at production Firebase; avoid destructive tests if it does.
+- Merge into `develop`, verify non-destructive list and reconnect behavior at `https://dev.click-battle.com.ar/`, and inspect cleanup permissions in the intended environment.
+- Promote to `master` only through a PR after branch and integrated validation pass.

--- a/specs/002-cleanup-ghost-rooms/research.md
+++ b/specs/002-cleanup-ghost-rooms/research.md
@@ -1,0 +1,156 @@
+# Research: Automatic Ghost Room Cleanup
+
+## Decision 1: Trigger cleanup from room-list evaluation
+
+**Decision**: Reuse the existing Realtime Database `onValue` room-list subscription. Classify every raw room before setting visible list state, hide stale rooms immediately, and start their deletion asynchronously.
+
+**Rationale**: This directly matches the requested traffic-driven behavior, fixes the player-facing symptom before any write finishes, and avoids scheduled infrastructure. It also extends logic already present in `app/page.tsx` instead of creating a second lifecycle system.
+
+**Alternatives considered**:
+
+- Scheduled Cloud Function, Vercel Cron, or queue worker: rejected because the user explicitly wants to avoid jobs and the current scale does not justify new infrastructure.
+- Filter only, without deletion: rejected because stale active records would keep accumulating and still require manual Firebase cleanup.
+- Cleanup only when a player opens a room: rejected because ghosts would remain visible in the list and invite users into dead sessions.
+
+## Decision 2: Use one viewer deadline timer, not viewer polling
+
+**Decision**: Retain the latest raw room and disconnect-signal snapshots and schedule one timeout for the nearest 30-second disconnect deadline, 90-second lease deadline, or 24-hour legacy deadline. On timeout, reevaluate, update the visible list, and attempt deletion for newly stale rooms. The host heartbeat is a bounded writer owned by the host session; viewers do not poll.
+
+**Rationale**: Realtime Database does not emit a second snapshot merely because wall-clock time passed. The current implementation can therefore leave a room visible indefinitely when its disconnect marker arrives during the grace period. A single nearest-deadline timeout closes that gap without polling or a recurring process.
+
+**Alternatives considered**:
+
+- `setInterval` polling: rejected because it creates continuous work and unnecessary reevaluations.
+- One timeout per room: rejected because one reschedulable timeout is easier to cancel and has lower timer overhead.
+- Wait for another Firebase update: rejected because no later update is guaranteed.
+
+## Decision 3: Guard deletion with a Realtime Database transaction
+
+**Decision**: Replace unconditional cleanup `remove()` calls with a helper that runs a transaction at `games/{gameId}`. The transaction reclassifies the current value and returns `null` only if it is still stale; it aborts when the room is missing, active, pending, recovered, or ambiguous.
+
+**Rationale**: A host can reconnect after a list snapshot marks a room stale but before deletion reaches the database. Rechecking at commit time prevents that race and makes concurrent cleanup attempts idempotent. Firebase documents transactions as the mechanism for updates that depend on current data.
+
+**Alternatives considered**:
+
+- Keep unconditional `remove()`: rejected because it can delete a recovered room.
+- Compare only the previously observed connection identifier: rejected because legacy-age cleanup also needs a safe current-value check.
+- Add a server endpoint for deletion: rejected because it adds backend surface and deployment complexity that the transaction can avoid at current scope.
+
+## Decision 4: Make the server-timestamped lease authoritative
+
+**Decision**: Add `hostLease { ownerId, sessionId, claimedAt, lastRenewedAt }` inside each modern room and use the existing `.info/serverTimeOffset` helper for comparisons. Classify rooms as follows:
+
+- A lease renewed less than 90 seconds ago: `active`, unless a later matching disconnect signal is pending.
+- A matching session disconnect signal before its 30-second deadline: `pending`.
+- A matching session disconnect signal after its deadline, with no later renewal: `stale-host-disconnect`.
+- A lease at least 90 seconds old: `stale-lease-expired`, with no additional grace.
+- No usable lease or disconnect evidence plus numeric `created` older than 24 hours: `stale-legacy-age`.
+- Missing or malformed evidence that does not satisfy a stale rule: `unknown`, kept visible if otherwise parseable and never deleted by cleanup.
+
+**Rationale**: A non-empty `hostConnectionId` can survive a failed `onDisconnect` and is therefore not proof of liveness. The renewed lease bounds that failure to 90 seconds. Server timestamps prevent client clock skew from deciding destructive behavior, while conservative legacy handling protects ambiguous young rooms.
+
+**Alternatives considered**:
+
+- Use `Date.now()` directly: rejected because a badly skewed device could delete too early or retain ghosts too long.
+- Continue trusting `hostConnectionId`: rejected because that is the exact failure mode that can leave a ghost forever.
+- Use the 2-second/3.5-second timing from the reference project: rejected because ClickBattle closes rather than transfers the room, making false positives destructive.
+- Delete every room older than 24 hours: rejected because age alone must not override a valid current lease.
+- Delete malformed snapshots: rejected because ambiguity is not sufficient evidence for a destructive action.
+
+## Decision 5: Cover the current list and direct links
+
+**Decision**: Apply the same pure classification to `app/page.tsx` and the stale branch in `hooks/useRoomGame.ts`. Leave the obsolete `/legacy` UI unchanged.
+
+**Rationale**: Direct links can bypass the current list. Shared classification prevents `/game/{gameId}` from joining a room that `/` considers stale, without investing in a UI route scheduled for removal.
+
+**Alternatives considered**:
+
+- Update `/legacy` as well: rejected after product clarification that the route is obsolete and will be removed.
+- Rewrite the current page around a new global room-list hook: rejected as a broader refactor than the feature needs.
+
+## Decision 6: Do not create cleanup history
+
+**Decision**: Opportunistic cleanup removes only the active room record. It does not create or mutate Firestore room-history summaries.
+
+**Rationale**: A list viewer does not own the host's in-memory statistics, and inventing partial history would distort analytics. Existing intentional-close history behavior remains unchanged.
+
+**Alternatives considered**:
+
+- Write a minimal automatic-expiration history row: rejected because it would change analytics semantics and require additional cross-store permissions.
+- Delete existing history: rejected because active-room cleanup must not destroy retained historical records.
+
+## Decision 7: Verify with emulators and authenticated Playwright users
+
+**Decision**: Extend the existing authenticated fixtures to seed lifecycle states in the Realtime Database emulator, then test list visibility and eventual database deletion. Run auth setup before the logged-in E2E cases.
+
+**Rationale**: These are user-visible and destructive realtime flows. The repository already has Playwright, authenticated storage states, and Firebase emulator helpers. Next.js guidance recommends E2E testing through a running application; project instructions require auth setup and warn that previews may point at production Firebase.
+
+**Alternatives considered**:
+
+- Manual Firebase console verification: rejected as destructive, difficult to repeat, and unable to prove race handling.
+- Introduce a new unit-test framework only for the classifier: rejected for this narrow feature; deterministic helper branches can be exercised through focused Playwright scenarios without adding tooling.
+
+## Decision 8: Treat deployed rules as a release gate, not an invitation to broaden access
+
+**Decision**: Expect no security-rule change because the current client already removes room paths, but explicitly verify on the emulator and safe branch environment that authenticated list viewers can complete the guarded transaction. If deployed rules reject it, amend the design with the narrowest conditional rule rather than granting broad delete access.
+
+**Rationale**: `database.rules.json` currently denies all and is not wired into `firebase.json`, so it does not reliably describe deployed production permissions. Guessing or broadening rules during planning would violate environment separation and Firebase contract discipline.
+
+**Alternatives considered**:
+
+- Commit permissive rules now: rejected as unsafe and unsupported by repository configuration.
+- Ignore permission behavior: rejected because filtering without successful cleanup would only partially solve the user request.
+
+## Decision 9: Renew a narrow embedded lease with session-checked transactions
+
+**Decision**: The active room stores `hostLease` with `ownerId`, `sessionId`, `claimedAt`, and `lastRenewedAt`. The current host renews it every 20 seconds through a transaction at `games/{gameId}/hostLease`. The update function returns a new server timestamp only when the existing owner and session match; null or mismatched data aborts.
+
+**Rationale**: A transaction at the lease node avoids conflict with frequent click/game-state writes. Requiring an existing matching lease means a delayed interval cannot recreate a deleted room or renew a replaced session. New rooms initialize the lease with room creation; legacy bootstrap is a separate one-time guarded path.
+
+**Alternatives considered**:
+
+- Transaction at the entire room every 20 seconds: rejected because every game-state write below that path could cause retries and contention.
+- Unconditional `update()` heartbeat: rejected because a delayed client could recreate a partial room after deletion.
+- Trust client `Date.now()`: rejected because lease expiry is destructive and must use server-aligned committed time.
+
+## Decision 10: Move `onDisconnect` evidence outside the active-room path
+
+**Decision**: Register `onDisconnect` at `roomHostDisconnects/{gameId}/{sessionId}` and write a server `disconnectedAt` timestamp. The classifier uses only a signal matching the room's current lease session. Matching signals preserve the fast 30-second path; lease expiry remains the 90-second fallback when no reliable signal arrives.
+
+**Rationale**: The existing `onDisconnect(...gameRef).update(...)` can recreate partial `games/{gameId}` data if another client deletes the room before the host connection finally closes. A separate session-scoped signal cannot recreate the active room, and an old session cannot mark a new session disconnected.
+
+**Alternatives considered**:
+
+- Keep writing disconnect timestamps under the room: rejected because delayed callbacks can recreate deleted room data.
+- `onDisconnect(room).remove()`: rejected because it bypasses the reconnect grace and can delete a room after a newer session connects.
+- Remove `onDisconnect` entirely: rejected because it would make every unexpected disconnect wait the full 90-second lease.
+
+## Decision 11: No takeover and no host/player presence redesign
+
+**Decision**: Lease expiry closes the room. It does not elect another host, modify player authority, or introduce player heartbeats. Existing visitor `onDisconnect(...player).remove()` behavior remains unchanged.
+
+**Rationale**: Host takeover changes game authority and product behavior far beyond ghost-room cleanup. The user explicitly selected close-on-expiry. Player cleanup is already separate from the host-room ghost problem.
+
+**Alternatives considered**:
+
+- Deterministic oldest-player takeover: rejected for this feature because it requires authority migration, game-state continuity rules, and substantially broader testing.
+- Player heartbeat redesign: deferred because it is not required to prove host availability or delete abandoned rooms.
+
+## Decision 12: Revalidate deletion using embedded renewal evidence
+
+**Decision**: Keep deletion transactional at `games/{gameId}`. For lease expiry, recheck the current `lastRenewedAt`. For disconnect cleanup, also require the expected session and ensure the current lease was not renewed after the observed disconnect timestamp. Remove sibling disconnect signals only after room deletion commits.
+
+**Rationale**: Reconnection writes the embedded lease before clearing the external signal, so the transaction can reject deletion even if signal cleanup races. This preserves idempotency without a transaction at the database root.
+
+**Alternatives considered**:
+
+- Delete based only on the last list snapshot: rejected because renewal may commit between classification and deletion.
+- Root-level transaction across room and signal: rejected because its contention and data scope are disproportionate.
+- Write cleanup history: rejected because active-room lifecycle cleanup must remain isolated from Firestore analytics.
+
+## Sources
+
+- Firebase Realtime Database offline/presence behavior: https://firebase.google.com/docs/database/web/offline-capabilities
+- Firebase Realtime Database reads, writes, and transactions: https://firebase.google.com/docs/database/web/read-and-write
+- Next.js Server and Client Components: https://nextjs.org/docs/app/getting-started/server-and-client-components
+- Next.js Playwright testing guide: https://nextjs.org/docs/app/guides/testing/playwright

--- a/specs/002-cleanup-ghost-rooms/spec.md
+++ b/specs/002-cleanup-ghost-rooms/spec.md
@@ -1,0 +1,143 @@
+# Feature Specification: Automatic Ghost Room Cleanup
+
+**Feature Branch**: `002-cleanup-ghost-rooms`
+
+**Created**: 2026-06-24
+
+**Status**: Draft
+
+**Input**: User description: "Quiero dejar de tener salas fantasma que quedan eternamente hasta que yo las elimino a mano desde firebase"
+
+## Clarifications
+
+### Session 2026-06-24
+
+- Q: Should ClickBattle transfer host authority when the current host lease expires? → A: No. Heartbeat is used only to detect abandonment; an expired host lease closes the room.
+- Q: What heartbeat frequency and host-lease duration should ClickBattle use? → A: Renew every 20 seconds; expire after 90 seconds without a successful renewal.
+- Q: Does an expired 90-second host lease start an additional reconnect grace period? → A: No. At 90 seconds the room is immediately stale, hidden, and eligible for guarded deletion.
+- Q: What happens when browser suspension prevents heartbeat renewal for more than 90 seconds? → A: The lease remains authoritative and the room closes; a suspended host is no longer considered reliably available.
+- Q: Which host session may renew the lease? → A: Only the current host and current `sessionID`, and only while the room still exists; delayed or replaced sessions cannot renew or recreate it.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Close Abandoned Rooms Automatically (Priority: P1)
+
+As the product operator, I want an abandoned room to be hidden and cleaned when players evaluate the room list so that ghost rooms stop reaching users without requiring scheduled infrastructure.
+
+**Why this priority**: This directly eliminates the manual cleanup burden and prevents players from encountering rooms that can no longer be played.
+
+**Independent Test**: Create a room, disconnect the host unexpectedly, wait for the reconnect grace period to expire, and open the room list as another user. Verify that the abandoned room is never shown and is removed in the background.
+
+**Acceptance Scenarios**:
+
+1. **Given** a host disconnects unexpectedly and does not return during the 30-second grace period, **When** any user next loads or receives an update to the active room list, **Then** the abandoned room is excluded before display and its background deletion is requested.
+2. **Given** a host disconnects while no guests remain in the room, **When** no one is viewing the room list, **Then** the room may remain stored until the next room-list evaluation but MUST NOT be displayed once that evaluation occurs.
+3. **Given** a host disconnects while guests remain in the room, **When** the grace period expires, **Then** the room closes through the existing connected-player lifecycle or the next room-list evaluation, whichever occurs first.
+4. **Given** a host intentionally leaves through the available room-exit action, **When** the exit completes, **Then** the room closes immediately without waiting for the unexpected-disconnect grace period.
+
+---
+
+### User Story 2 - Survive Brief Host Reconnection (Priority: P2)
+
+As a room host, I want a brief network interruption or page reload to preserve my room so that an ordinary reconnect does not destroy an active match.
+
+**Why this priority**: Automatic cleanup must solve abandoned rooms without making live gameplay fragile.
+
+**Independent Test**: Disconnect and reconnect the host before the grace period expires, then verify that the same room, players, mode, and game state remain available.
+
+**Acceptance Scenarios**:
+
+1. **Given** a host loses connection, **When** the same host reconnects within 30 seconds, **Then** pending room closure is cancelled and the room remains active.
+2. **Given** a long-running room has an available host but no recent gameplay action, **When** opportunistic cleanup evaluates the room, **Then** the room remains active.
+
+---
+
+### User Story 3 - Remove Existing Ghost Rooms Safely (Priority: P2)
+
+As the product operator, I want already-abandoned rooms to be cleared after the feature becomes operational so that the current backlog of ghost rooms disappears without a one-off manual deletion.
+
+**Why this priority**: Preventing new ghosts does not remove the stale rooms that already create operational work and a misleading room list.
+
+**Independent Test**: Seed old active-room records with no usable evidence of an available host, including a legacy-shaped room, and verify they are cleaned while a room with a currently available host is preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pre-existing room has no usable host-presence evidence and was created more than 24 hours ago, **When** a user loads or receives an update to the room list, **Then** the room is excluded before display and removed in the background.
+2. **Given** a pre-existing room has incomplete lifecycle metadata but its host is currently available, **When** cleanup evaluates it, **Then** the room is preserved.
+3. **Given** multiple cleanup evaluations target the same stale room, **When** they complete in any order, **Then** the room is closed once without errors, duplicate history, or effects on other rooms.
+
+### Edge Cases
+
+- The host disconnects and reconnects exactly at the grace-period boundary.
+- The room is created but the host connection is lost before the game screen finishes opening.
+- The host deliberately closes the room while an automatic cleanup decision is already pending.
+- Two or more cleanup evaluations attempt to close the same room concurrently.
+- Guests try to join from a stale room card or direct link while the room is being closed.
+- A cleanup attempt is interrupted or temporarily fails after identifying an abandoned room.
+- No user opens the room list for an extended period after a room becomes stale.
+- A legacy room lacks newer lifecycle fields, mode metadata, or a complete participant list.
+- A room remains open for many hours with an available host but no game rounds are started.
+- The host browser is backgrounded or suspended long enough for the 90-second lease to expire.
+- A delayed heartbeat from an obsolete host session arrives after reconnection, session replacement, or room deletion.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST maintain enough current host-availability information to distinguish an active room from an abandoned room.
+- **FR-002**: The system MUST close a room immediately when its host intentionally uses the supported room-exit action.
+- **FR-003**: The system MUST allow an unexpectedly disconnected host a 30-second reconnect grace period before declaring the room abandoned.
+- **FR-004**: The system MUST cancel pending abandonment cleanup when a valid host connection returns during the grace period.
+- **FR-005**: Every room-list evaluation MUST identify stale rooms before rendering, exclude them from the player-visible list, and request their deletion in the background.
+- **FR-006**: Closing an abandoned room MUST remove its active-room record rather than only hiding it from the room list.
+- **FR-007**: A closed room MUST no longer appear in active room listings and MUST reject new join attempts, including direct-link attempts.
+- **FR-008**: Players who attempt to enter a room that has already been removed MUST follow the existing unavailable-room fallback without being added to a new room session.
+- **FR-009**: The cleanup behavior MUST apply consistently to every supported game mode in the current room list and game routes.
+- **FR-010**: Cleanup MUST preserve a room while its current host session is available, regardless of room age or recent gameplay activity.
+- **FR-011**: Pre-existing active-room records that lack usable host-availability evidence and are older than 24 hours MUST be treated as stale during room-list evaluation, excluded before display, and queued for background deletion.
+- **FR-012**: Pre-existing or legacy-shaped rooms with a currently available host MUST not be removed solely because lifecycle metadata is missing or incomplete.
+- **FR-013**: Repeated or concurrent cleanup decisions for the same room MUST be safe and MUST NOT create duplicate history or affect unrelated rooms.
+- **FR-014**: A temporarily failed cleanup MUST remain eligible for later automatic retry and MUST NOT require manual deletion to recover.
+- **FR-015**: The feature MUST NOT require a scheduled job, recurring backend task, or continuously running cleanup process.
+- **FR-016**: A room-list view that is already open MUST reevaluate a disconnected room when its grace period expires, even if no additional room data changes arrive.
+- **FR-017**: Opportunistic cleanup MUST NOT create new historical room summaries; existing history records and existing intentional-close history behavior MUST remain unchanged.
+- **FR-018**: The system MUST NOT transfer room ownership when host availability expires; heartbeat expiry MUST lead to the existing room-closure flow rather than host takeover.
+- **FR-019**: While the host session is active, the system MUST renew server-timestamped host availability every 20 seconds, and that availability MUST expire after 90 seconds without a successful renewal.
+- **FR-020**: Host-lease expiration MUST be the final abandonment boundary: at 90 seconds without renewal the room MUST be classified stale without adding the separate 30-second disconnect grace period.
+- **FR-021**: Host-lease expiration MUST remain authoritative when browser throttling, backgrounding, device sleep, or suspension prevents renewal; a room MUST NOT be preserved solely because an older connection identifier remains stored.
+- **FR-022**: A host-lease renewal MUST be accepted only while the room exists and both the host identity and `sessionID` match the room's current host session; an obsolete or delayed session MUST NOT extend the lease or recreate a deleted room.
+
+### Key Entities
+
+- **Active Room**: A currently joinable game space with an identifier, host, participants, game mode, creation time, current state, and host-availability status.
+- **Host Connection**: Evidence that the room's current host session is available.
+- **Host Lease**: Server-timestamped host-availability evidence renewed every 20 seconds and considered expired after 90 seconds without renewal.
+- **Host Session**: The unique `sessionID` paired with the room's current host identity; together they authorize lease renewal until that session is replaced or the room is removed.
+- **Pending Room Expiration**: The temporary state between an unexpected loss of the last host connection and the end of the reconnect grace period.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In acceptance testing, 100% of rooms already stale when a room list is evaluated are absent from the rendered list and have deletion requested within five seconds of that evaluation.
+- **SC-002**: In acceptance testing, 100% of hosts that reconnect within the 30-second grace period retain the same room and game state.
+- **SC-003**: In at least 100 tested active-room lifecycle variations, no room with a valid available host is removed by automatic cleanup.
+- **SC-004**: Pre-existing rooms older than 24 hours with no usable evidence of an available host are never rendered and have deletion requested during the first room-list evaluation that encounters them.
+- **SC-005**: A guest in a room that expires reaches a safe non-game screen with an understandable explanation within five seconds of the closure becoming observable.
+- **SC-006**: No scheduled or continuously running cleanup process is required to satisfy the accepted room-list scenarios.
+- **SC-007**: A failed background deletion is retried on a later room-list evaluation while the stale room remains hidden from players.
+- **SC-008**: When no reliable disconnect timestamp is produced, a room with no successful host-lease renewal is classified stale, excluded from the room list, and eligible for guarded deletion no later than 90 seconds after its last server-timestamped renewal.
+- **SC-009**: Acceptance coverage explicitly treats a host browser suspended beyond 90 seconds as unavailable and produces the same stale classification as any other missed-lease scenario.
+- **SC-010**: Delayed heartbeat attempts from a replaced host session or a deleted room are rejected in 100% of acceptance race scenarios and never recreate an active-room record.
+
+## Assumptions
+
+- Room ownership is not transferred when the host disappears; heartbeat is only an abandonment signal and an expired host lease closes the room through the existing cleanup flow.
+- Supporting multiple simultaneous host tabs or devices is outside this feature; the existing single-host-session behavior remains unchanged.
+- Thirty seconds is the established reconnect tolerance for unexpected host disconnections and is sufficient for ordinary reloads or brief network interruptions.
+- A host whose browser cannot renew the lease for 90 seconds is intentionally treated as unavailable, including when caused by background throttling or device suspension.
+- A 24-hour age threshold is a conservative fallback only for pre-existing records that lack usable host-availability evidence; current host availability always takes precedence over age.
+- Cleanup is opportunistic: if nobody evaluates the room list, a stale active-room record may remain stored until the next evaluation.
+- Existing room history remains unchanged; opportunistic stale-room deletion does not create a new historical summary.
+- Both classic-speed and Reaction Battle rooms are in scope through the current `/` and `/game/{gameId}` flows; the obsolete `/legacy` UI is out of scope.
+- Temporary service failures may delay cleanup, but automatic retry is expected to restore the target outcome without operator intervention.

--- a/specs/002-cleanup-ghost-rooms/tasks.md
+++ b/specs/002-cleanup-ghost-rooms/tasks.md
@@ -1,0 +1,223 @@
+# Tasks: Automatic Ghost Room Cleanup
+
+**Input**: Design documents from `/specs/002-cleanup-ghost-rooms/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [room-cleanup-contract.md](contracts/room-cleanup-contract.md), [quickstart.md](quickstart.md)
+
+**Tests**: The specification requires authenticated Playwright coverage. Run `tests/e2e/auth.setup.ts` before logged-in room tests, and run destructive scenarios only against the Firebase emulators unless the environment is explicitly confirmed safe.
+
+**Organization**: Tasks are grouped by user story. The existing first cleanup increment is treated as a baseline to extend, not as proof that the new lease requirements are complete.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches different files and has no dependency on an incomplete task.
+- **[Story]**: Maps implementation and validation to US1, US2, or US3.
+- Every task includes the exact file path or paths it must inspect or modify.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Reconfirm the destructive-test boundary and prepare lease/session fixture controls.
+
+- [x] T001 Verify emulator-only destructive testing, authenticated player setup, and the unconfigured Realtime Database rules boundary in `firebase.json`, `database.rules.json`, `tests/e2e/auth.setup.ts`, and `specs/002-cleanup-ghost-rooms/quickstart.md`
+- [x] T002 [P] Extend `tests/e2e/fixtures.ts` with helpers to create, read, renew, expire, replace, and remove `hostLease` values plus session-scoped `roomHostDisconnects/{gameId}/{sessionId}` signals
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define the shared lease model and race-safe primitives required by every user story.
+
+**CRITICAL**: No user-story integration begins until this phase is complete.
+
+- [x] T003 [P] Add `HostLease`, `HostDisconnectSignal`, and raw lifecycle snapshot typing to `interfaces/Game.ts`, retaining legacy fields only as compatibility inputs
+- [x] T004 [P] Implement session ID creation, initial lease construction, 20-second heartbeat constants, 90-second expiry constants, and conditional lease-renewal transactions in `lib/game/hostLease.ts`
+- [x] T005 [P] Extend pure lifecycle classification with current-session disconnect evidence, lease-active, lease-expired, and next-deadline outcomes in `lib/game/hostPresence.ts`
+- [x] T006 Extend partitioning and guarded deletion to carry expected session/disconnect evidence, recheck current lease renewal at commit time, and best-effort remove sibling signals in `lib/game/roomCleanup.ts`
+
+**Checkpoint**: A delayed or mismatched heartbeat cannot create/renew a missing lease, and stale classification is deterministic without touching UI code.
+
+---
+
+## Phase 3: User Story 1 - Close Abandoned Rooms Automatically (Priority: P1) MVP
+
+**Goal**: New rooms publish an authoritative lease, hosts renew it every 20 seconds, reliable disconnects retain the 30-second path, and missing disconnect callbacks still close the room at 90 seconds without jobs.
+
+**Independent Test**: Create a modern room, stop successful lease renewal while retaining its old connection identifier and omitting a disconnect signal, then prove another authenticated viewer sees it before 90 seconds, never sees it after the deadline, and removes it without an extra grace period; repeat with a matching disconnect signal for the 30-second path and through a direct link.
+
+### Tests for User Story 1
+
+> Write these cases first and confirm they fail for the missing lease behavior.
+
+- [x] T007 [US1] Add failing Playwright cases for initial lease creation, two 20-second renewals, 89-to-90-second expiry with a stale connection identifier, no additional grace, matching-session 30-second disconnect cleanup, and stale direct-link rejection in `tests/e2e/game.spec.ts`
+
+### Implementation for User Story 1
+
+- [x] T008 [P] [US1] Generate the first host session and atomically create the room with its initial server-timestamped `hostLease` in `components-new/CreateSection/index.tsx`
+- [x] T009 [US1] Replace inline room `onDisconnect` mutation with `roomHostDisconnects/{gameId}/{sessionId}` registration and start/stop the conditional 20-second heartbeat in `hooks/useRoomGame.ts`
+- [x] T010 [P] [US1] Subscribe to and combine current room plus disconnect-signal snapshots, filter before rendering, and schedule the nearest 30-second or 90-second deadline in `app/page.tsx`
+- [x] T011 [US1] Feed matching disconnect evidence into the shared classifier before state application or visitor writes in `hooks/useRoomGame.ts`
+- [x] T012 [US1] Preserve intentional host exit by cancelling the current disconnect signal, removing the active room immediately, and cleaning its signal subtree in `hooks/useRoomGame.ts`
+- [x] T013 [US1] Run authenticated setup and the focused US1 heartbeat, lease-expiry, disconnect-grace, and direct-link cases from `tests/e2e/auth.setup.ts` and `tests/e2e/game.spec.ts` against local emulators
+
+**Checkpoint**: The original ghost-room failure is bounded to 90 seconds even when `onDisconnect` produces no usable room signal.
+
+---
+
+## Phase 4: User Story 2 - Survive Brief Host Reconnection (Priority: P2)
+
+**Goal**: A valid returning owner replaces or renews the current session safely, while delayed work from an obsolete session cannot close, extend, or recreate the room.
+
+**Independent Test**: Disconnect and reconnect the owner before the applicable deadline, replace the session, then deliver an old heartbeat and old disconnect signal. The room and game state remain, only the new session renews, and a heartbeat submitted after room deletion cannot recreate `games/{gameId}`.
+
+### Tests for User Story 2
+
+- [x] T014 [US2] Add failing Playwright race cases for same-session recovery, owner session replacement, obsolete heartbeat rejection, obsolete disconnect-signal rejection, suspension beyond 90 seconds, and post-deletion heartbeat non-recreation in `tests/e2e/game.spec.ts`
+
+### Implementation for User Story 2
+
+- [x] T015 [P] [US2] Implement owner-only session replacement that aborts for missing rooms, different owners, or absent modern leases in `lib/game/hostLease.ts`
+- [x] T016 [US2] Order reconnection as session registration, committed lease renewal, matching-signal cleanup, and old-loop shutdown without restarting room state when server-time offset changes in `hooks/useRoomGame.ts`
+- [x] T017 [P] [US2] Reject guarded deletion when the room references a different session or has `lastRenewedAt` newer than the observed disconnect signal in `lib/game/roomCleanup.ts`
+- [x] T018 [US2] Ensure room-null listeners stop heartbeat ownership and route hosts, controllers, and guests through the existing unavailable-room fallback in `hooks/useRoomGame.ts`
+- [x] T019 [US2] Run the focused reconnect, replacement-session, stale-callback, suspended-host, and post-deletion non-recreation Playwright cases in `tests/e2e/game.spec.ts`
+
+**Checkpoint**: Reconnects preserve live games, but an obsolete session has no authority over the lease or active-room path.
+
+---
+
+## Phase 5: User Story 3 - Remove Existing Ghost Rooms Safely (Priority: P2)
+
+**Goal**: Pre-lease ghosts, including records with misleading old connection identifiers, clean after 24 hours while a currently open owner session can safely bootstrap a lease.
+
+**Independent Test**: Seed an old room with `hostConnectionId` but no lease and prove it is hidden/deleted; seed a comparable room opened by its authenticated owner and prove one guarded bootstrap establishes a current lease before cleanup; run concurrent viewers and confirm idempotency and no Firestore history.
+
+### Tests for User Story 3
+
+- [x] T020 [US3] Add failing Playwright cases for old pre-lease rooms with stale connection identifiers, young ambiguous rooms, owner lease bootstrap, concurrent cleanup, and absence of cleanup-only Firestore history in `tests/e2e/game.spec.ts`
+
+### Implementation for User Story 3
+
+- [x] T021 [P] [US3] Treat legacy `hostConnectionId` without a usable lease as non-authoritative and apply the conservative 24-hour fallback in `lib/game/hostPresence.ts`
+- [x] T022 [P] [US3] Implement one-time owner-verified whole-room lease bootstrap for an existing room with no `hostLease`, while aborting for missing rooms and non-owners, in `lib/game/hostLease.ts`
+- [x] T023 [US3] Invoke legacy lease bootstrap only for the parsed authenticated owner before starting heartbeat ownership in `hooks/useRoomGame.ts`
+- [x] T024 [US3] Run focused pre-lease backlog, active-owner bootstrap, concurrent viewer, and no-history Playwright cases in `tests/e2e/game.spec.ts`
+
+**Checkpoint**: The old backlog no longer survives merely because it contains a stale connection string, and active owners can migrate safely without a data job.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Reconcile documentation, verify permissions and regressions, and protect explicit scope boundaries.
+
+- [x] T025 [P] Reconcile final field names, state precedence, and validation results across `specs/002-cleanup-ghost-rooms/spec.md`, `specs/002-cleanup-ghost-rooms/plan.md`, `specs/002-cleanup-ghost-rooms/data-model.md`, `specs/002-cleanup-ghost-rooms/contracts/room-cleanup-contract.md`, and `specs/002-cleanup-ghost-rooms/quickstart.md`
+- [x] T026 Run TypeScript, targeted ESLint, and translation validation using `package.json` scripts, fixing every lease-related failure in `components-new/CreateSection/index.tsx`, `hooks/useRoomGame.ts`, `app/page.tsx`, `interfaces/Game.ts`, and `lib/game/*.ts`
+- [x] T027 Run authenticated setup followed by all focused lifecycle scenarios documented in `specs/002-cleanup-ghost-rooms/quickstart.md` against the Firebase emulators
+- [x] T028 Run the complete Chromium regression suite in `tests/e2e/game.spec.ts`, covering classic-speed, Reaction Battle, passwords, intentional host exit, reconnects, and legacy-shaped room data
+- [x] T029 Validate read/write/delete behavior for `games/{gameId}/hostLease` and `roomHostDisconnects/{gameId}/{sessionId}` under emulator and deployed-equivalent rules without broadening `database.rules.json` or testing destructive writes against an unsafe environment
+  - Verified in `specs/002-cleanup-ghost-rooms/permission-validation.md` using an isolated auth+RTDB emulator loaded with the deployed-equivalent ruleset: unauthenticated clients are denied, authenticated clients are allowed for the required lease and disconnect-signal operations.
+- [x] T030 Review `firebase.json`, `database.rules.json`, `app/legacy/page.tsx`, the final git diff, and runtime timers to confirm no `/legacy` change, takeover, cron/job/backend service, viewer polling loop, room recreation path, or cleanup-only Firestore write was introduced
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 - Setup**: Starts immediately and establishes safe test controls.
+- **Phase 2 - Foundation**: Depends on Setup and blocks every story. T004-T005 depend on T003; T006 depends on T005.
+- **Phase 3 - US1**: Depends on Foundation and is the release MVP.
+- **Phase 4 - US2**: Depends on US1 heartbeat/session integration and hardens its races.
+- **Phase 5 - US3**: Depends on Foundation and the US1 host lifecycle; its failing tests may be prepared while US2 is implemented.
+- **Phase 6 - Polish**: Depends on every selected story.
+
+### User Story Dependency Graph
+
+```text
+Setup -> Foundation -> US1 (MVP) -> US2
+                              `----> US3
+US2 + US3 -> Polish
+```
+
+### User Story Dependencies
+
+- **US1 (P1)**: Delivers the authoritative lease, heartbeat, disconnect signal, list filtering, and direct-link behavior.
+- **US2 (P2)**: Builds on US1 to protect reconnect and delayed-session races; independently testable through session replacement scenarios.
+- **US3 (P2)**: Reuses the lease model to clean/migrate pre-lease data; independently testable with seeded old rooms.
+
+### Within Each User Story
+
+- Add the story's Playwright cases first and confirm failure for the missing behavior.
+- Implement pure types/classification and transaction primitives before UI/hook integration.
+- Commit server renewal before clearing disconnect evidence.
+- Filter before rendering and recheck destructive evidence inside the room transaction.
+- Complete the story's focused emulator checkpoint before advancing.
+
+### Parallel Opportunities
+
+- T002 and T003 can proceed in parallel after T001 confirms emulator safety.
+- After T003, T004 and T005 touch separate modules and can proceed in parallel before T006 integrates them.
+- T014 (US2 tests) and T020 (US3 tests) can be prepared in parallel after US1 stabilizes, with coordinated edits to `tests/e2e/game.spec.ts`.
+- T015-T018 and T021-T023 target different primary modules but must coordinate shared edits to `hooks/useRoomGame.ts` and `lib/game/hostLease.ts`.
+- T025 documentation reconciliation can proceed alongside T026 static validation once implementation stabilizes.
+
+---
+
+## Parallel Examples
+
+### User Story 1
+
+```text
+Task A: T008 add atomic new-room lease initialization in components-new/CreateSection/index.tsx
+Task B: T010 combine room/signal snapshots and deadlines in app/page.tsx
+```
+
+Start both after T007 has failed for the expected missing lease behavior.
+
+### User Story 2 and User Story 3
+
+```text
+Task A: T014-T019 implement and validate reconnect/session race safety
+Task B: T020-T024 implement and validate pre-lease migration/backlog cleanup
+```
+
+Coordinate `tests/e2e/game.spec.ts`, `hooks/useRoomGame.ts`, and `lib/game/hostLease.ts` before merging the streams.
+
+---
+
+## Implementation Strategy
+
+### MVP First: User Story 1
+
+1. Complete Setup and Foundation.
+2. Add US1 failing tests.
+3. Initialize leases, start conditional heartbeat, move disconnect evidence outside the room, and integrate current list/direct links.
+4. Stop and validate the no-`onDisconnect` 90-second journey plus the reliable 30-second journey.
+5. Do not promote until the new path proves it cannot recreate a deleted room.
+
+### Incremental Delivery
+
+1. **Foundation**: Lease/session model and transactional primitives.
+2. **US1 MVP**: Bound new ghosts to 90 seconds and preserve 30-second reliable disconnect cleanup.
+3. **US2**: Reconnect, replacement, suspension, and delayed-callback safety.
+4. **US3**: Pre-lease backlog and guarded owner bootstrap.
+5. **Polish**: Full regression, permission gate, documentation, and scope audit.
+
+### Parallel Team Strategy
+
+After US1:
+
+- Developer A: US2 session-race implementation and tests.
+- Developer B: US3 legacy bootstrap/classification and tests.
+- Coordinate shared hook/helper/test files before integration.
+
+---
+
+## Notes
+
+- `[P]` means different files and no incomplete dependency.
+- Never run destructive cleanup tests against a preview or domain that may use production Firebase.
+- Do not introduce host takeover, player heartbeat redesign, cron configuration, Cloud Functions, queues, backend routes, or viewer polling.
+- Do not make `/legacy` changes; legacy-shaped data remains covered through current `/` and `/game/{gameId}` flows.
+- Do not broaden Realtime Database permissions as an incidental fix; failed permission validation requires a separate narrow rule decision.
+- Commit after each reviewed task or coherent task group.

--- a/tests/e2e/auth.utils.ts
+++ b/tests/e2e/auth.utils.ts
@@ -1,103 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {readFileSync} from "fs";
 import {Page} from "@playwright/test";
 
 const URL_LOCAL = "http://localhost:3000";
 
-export const authenticate = async (page: any, type: "user" | "host") => {
-  await page.goto(URL_LOCAL);
-
-  const auth = JSON.parse(readFileSync(`tests/.auth/${type}.json`, "utf-8"));
-  const storedUsername =
-    auth.origins[0].localStorage.find((storage: any) => storage.name === "user")
-      ?.value ?? "";
-
-  await page.evaluate(async (auth: any) => {
-    const indexedDB = window.indexedDB;
-    const localStorageAuth: any[] = auth.origins[0].localStorage;
-
-    for (const storage of localStorageAuth) {
-      const dbName = storage.name;
-      localStorage.setItem(storage.name, storage.value);
-
-      let dbData;
-      try {
-        dbData = JSON.parse(storage.value);
-      } catch (e) {
-        continue;
-      }
-      const tables = Object.keys(dbData);
-
-      const db: IDBDatabase = await new Promise((resolve, reject) => {
-        const req = indexedDB.open(dbName as string);
-        req.onsuccess = (event: any) => {
-          resolve(event.target.result);
-        };
-        req.onupgradeneeded = (event: any) => {
-          resolve(event.target.result);
-        };
-        req.onerror = (e) => {
-          reject(e);
-        };
-        req.onblocked = (event: any) => {
-          reject(event);
-        };
-      });
-
-      for (const table of tables) {
-        const transaction = db.transaction([table], "readwrite");
-        const objectStore = transaction.objectStore(table);
-
-        for (const key of Object.keys(dbData[table])) {
-          const value = dbData[table][key];
-
-          // Parse value in case of keyPath
-          let parsedValue =
-            typeof value !== "string" ? JSON.stringify(value) : value;
-          try {
-            parsedValue = JSON.parse(parsedValue);
-          } catch (e) {
-            // value type is not json, nothing to do
-          }
-
-          if (objectStore.keyPath != null) {
-            objectStore.put(parsedValue);
-          } else {
-            objectStore.put(parsedValue, key);
-          }
-        }
-      }
-    }
-  }, auth);
-
-  // Firebase Auth reads the restored IndexedDB state during app bootstrap.
-  // Reload once after seeding the browser storage so the home page hydrates
-  // with the authenticated guest profile before tests interact with it.
-  await page.reload({waitUntil: "networkidle"});
-
-  const usernameInput = page.getByPlaceholder(/Username|Nombre de usuario/i);
-  if (
-    storedUsername &&
-    (await usernameInput.isVisible({timeout: 2000}).catch(() => false))
-  ) {
-    await usernameInput.fill(storedUsername);
-    await page.getByRole("button", {name: /Choose|Elegir/i}).click();
-    await page.waitForLoadState("networkidle");
-  }
-};
-
-const getAuthResponse = (page: Page) => {
-  return page.waitForResponse(/identitytoolkit.googleapis/);
-};
-
 export const loginAsGuest = async (page: Page, name = "guestuser") => {
-  await page.goto("/");
+  await page.goto(URL_LOCAL, {waitUntil: "domcontentloaded"});
 
-  await page.getByRole("button", {name: "Login as guest"}).click();
+  const usernameInput = page.locator('input[placeholder="Username"]').last();
+  await usernameInput.waitFor({state: "visible", timeout: 5000});
+  await usernameInput.fill(name);
+  await page.getByRole("button", {name: /Choose|Elegir/i}).click();
+  await page.waitForTimeout(2000);
+};
 
-  await getAuthResponse(page);
-
-  await page.getByPlaceholder("Username").fill(name);
-
-  await page.click("text=Choose");
+export const authenticate = async (page: any, type: "user" | "host") => {
+  await loginAsGuest(page, type === "host" ? "guesthost1" : "guestuser1");
 };

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -6,10 +6,23 @@ import {
   get,
   getDatabase,
   ref,
-  set
+  remove,
+  runTransaction,
+  set,
+  update
 } from "firebase/database";
+import {
+  getApps as getAdminApps,
+  initializeApp as initializeAdminApp
+} from "firebase-admin/app";
+import {getFirestore as getAdminFirestore} from "firebase-admin/firestore";
 
-import type {Game} from "interfaces";
+import type {
+  Game,
+  HostDisconnectSignal,
+  HostLease,
+  RoomLifecycleSnapshot
+} from "interfaces";
 import {firebaseConfig} from "resources/config";
 
 import {authenticate} from "./auth.utils";
@@ -18,11 +31,16 @@ const TEST_DATABASE_URL =
   process.env.databaseURL ||
   process.env.DATABASE_URL ||
   "https://click-battle-mp-default-rtdb.firebaseio.com";
+const TEST_PROJECT_ID = process.env.projectId || "click-battle-emulator";
 
 const getTestDatabase = () => {
   const app =
     getApps().length === 0
-      ? initializeApp({...firebaseConfig, databaseURL: TEST_DATABASE_URL})
+      ? initializeApp({
+          ...firebaseConfig,
+          databaseURL: TEST_DATABASE_URL,
+          projectId: firebaseConfig.projectId || TEST_PROJECT_ID
+        })
       : getApp();
   const db = getDatabase(app, TEST_DATABASE_URL);
 
@@ -33,6 +51,15 @@ const getTestDatabase = () => {
   }
 
   return db;
+};
+
+const getTestAdminFirestore = () => {
+  process.env.FIRESTORE_EMULATOR_HOST = "127.0.0.1:8080";
+  const app =
+    getAdminApps().find(({name}) => name === "click-battle-e2e") ??
+    initializeAdminApp({projectId: TEST_PROJECT_ID}, "click-battle-e2e");
+
+  return getAdminFirestore(app);
 };
 
 class GenericPage {
@@ -104,6 +131,135 @@ class GenericPage {
 
     return snapshot.val() as Game | null;
   }
+
+  async setRawRoom(roomID: string, room: Partial<Game>) {
+    await set(ref(getTestDatabase(), `games/${roomID}`), room);
+  }
+
+  async patchRoomLifecycle(roomID: string, lifecycle: RoomLifecycleSnapshot) {
+    await update(ref(getTestDatabase(), `games/${roomID}`), lifecycle);
+  }
+
+  async getHostLease(roomID: string): Promise<HostLease | null> {
+    const snapshot = await get(
+      ref(getTestDatabase(), `games/${roomID}/hostLease`)
+    );
+
+    return snapshot.val() as HostLease | null;
+  }
+
+  async setHostLease(roomID: string, hostLease: HostLease | null) {
+    await set(ref(getTestDatabase(), `games/${roomID}/hostLease`), hostLease);
+  }
+
+  async expireHostLease(roomID: string, ageMs = 91_000) {
+    const hostLease = await this.getHostLease(roomID);
+
+    if (!hostLease) {
+      throw new Error(`Room ${roomID} does not have a host lease`);
+    }
+
+    await this.setHostLease(roomID, {
+      ...hostLease,
+      lastRenewedAt: Date.now() - ageMs
+    });
+  }
+
+  async renewHostLease(roomID: string, renewedAt = Date.now()) {
+    const hostLease = await this.getHostLease(roomID);
+
+    if (!hostLease) {
+      throw new Error(`Room ${roomID} does not have a host lease`);
+    }
+
+    await this.setHostLease(roomID, {
+      ...hostLease,
+      lastRenewedAt: renewedAt
+    });
+  }
+
+  async replaceHostLeaseSession(roomID: string, sessionID: string) {
+    const hostLease = await this.getHostLease(roomID);
+
+    if (!hostLease) {
+      throw new Error(`Room ${roomID} does not have a host lease`);
+    }
+
+    await this.setHostLease(roomID, {
+      ...hostLease,
+      sessionId: sessionID,
+      claimedAt: Date.now(),
+      lastRenewedAt: Date.now()
+    });
+  }
+
+  async attemptLeaseRenewal(
+    roomID: string,
+    ownerID: string,
+    sessionID: string
+  ): Promise<boolean> {
+    const result = await runTransaction(
+      ref(getTestDatabase(), `games/${roomID}/hostLease`),
+      (current: HostLease | null) => {
+        if (!current) {
+          return;
+        }
+
+        if (current.ownerId !== ownerID || current.sessionId !== sessionID) {
+          return;
+        }
+
+        return {
+          ...current,
+          lastRenewedAt: Date.now()
+        };
+      },
+      {applyLocally: false}
+    );
+
+    return result.committed;
+  }
+
+  async getDisconnectSignal(
+    roomID: string,
+    sessionID: string
+  ): Promise<HostDisconnectSignal | null> {
+    const snapshot = await get(
+      ref(getTestDatabase(), `roomHostDisconnects/${roomID}/${sessionID}`)
+    );
+
+    return snapshot.val() as HostDisconnectSignal | null;
+  }
+
+  async setDisconnectSignal(
+    roomID: string,
+    sessionID: string,
+    disconnectedAt: number
+  ) {
+    await set(
+      ref(getTestDatabase(), `roomHostDisconnects/${roomID}/${sessionID}`),
+      {
+        disconnectedAt
+      }
+    );
+  }
+
+  async removeDisconnectSignals(roomID: string) {
+    await remove(ref(getTestDatabase(), `roomHostDisconnects/${roomID}`));
+  }
+
+  async removeRoom(roomID: string) {
+    await remove(ref(getTestDatabase(), `games/${roomID}`));
+  }
+
+  async hasRoomHistory(roomID: string) {
+    const snapshot = await getTestAdminFirestore()
+      .collection("rooms")
+      .doc(roomID)
+      .get();
+
+    return snapshot.exists;
+  }
 }
 
 class HostPage extends GenericPage {}
@@ -118,18 +274,14 @@ type MyFixtures = {
 export * from "@playwright/test";
 export const test = base.extend<MyFixtures>({
   hostPage: async ({browser}, use) => {
-    const context = await browser.newContext({
-      storageState: "tests/.auth/host.json"
-    });
+    const context = await browser.newContext();
     const hostPage = new HostPage(await context.newPage());
     await authenticate(hostPage.page, "host");
     await use(hostPage);
     await context.close();
   },
   userPage: async ({browser}, use) => {
-    const context = await browser.newContext({
-      storageState: "tests/.auth/user.json"
-    });
+    const context = await browser.newContext();
     const userPage = new UserPage(await context.newPage());
     await authenticate(userPage.page, "user");
     await use(userPage);

--- a/tests/e2e/game.spec.ts
+++ b/tests/e2e/game.spec.ts
@@ -574,4 +574,281 @@ test.describe("Game", () => {
     await userPage.waitForTimeout(3000);
     await expect(userPage.getByRole("button", {name: "Click"})).toBeVisible();
   });
+
+  test("Should hide and delete a stale room from the modern room list", async ({
+    hostPage,
+    userPage: {page: userPage}
+  }) => {
+    const roomName = uniqueRoomName("ghost-room-stale");
+    const roomID = await hostPage.createRoom({roomName});
+
+    await hostPage.page.close();
+    await hostPage.expireHostLease(roomID);
+    await userPage.goto("/");
+
+    await expect(
+      userPage.getByRole("button", {name: new RegExp(roomName, "i")})
+    ).not.toBeVisible();
+    await expect.poll(() => hostPage.getRoom(roomID)).toBeNull();
+  });
+
+  test("Should reevaluate a disconnect grace deadline without another write", async ({
+    hostPage,
+    userPage: {page: userPage}
+  }) => {
+    const roomName = uniqueRoomName("disconnect-grace-room");
+    const roomID = await hostPage.createRoom({roomName});
+    const hostLease = await hostPage.getHostLease(roomID);
+
+    expect(hostLease).not.toBeNull();
+
+    await hostPage.page.close();
+    await hostPage.renewHostLease(roomID, Date.now() - 26_000);
+    await hostPage.setDisconnectSignal(
+      roomID,
+      hostLease!.sessionId,
+      Date.now() - 25_000
+    );
+    await userPage.goto("/");
+
+    const roomCard = userPage.getByRole("button", {
+      name: new RegExp(roomName, "i")
+    });
+    await expect(roomCard).toBeVisible();
+    await expect(roomCard).not.toBeVisible({timeout: 10_000});
+    await expect.poll(() => hostPage.getRoom(roomID)).toBeNull();
+  });
+
+  test("Should reject a stale room direct link before joining", async ({
+    hostPage,
+    userPage: {page: userPage}
+  }) => {
+    const roomName = uniqueRoomName("stale-room-direct");
+    const roomID = await hostPage.createRoom({roomName});
+    const hostLease = await hostPage.getHostLease(roomID);
+
+    expect(hostLease).not.toBeNull();
+
+    await hostPage.page.close();
+    await hostPage.renewHostLease(roomID, Date.now() - 32_000);
+    await hostPage.setDisconnectSignal(
+      roomID,
+      hostLease!.sessionId,
+      Date.now() - 31_000
+    );
+    await userPage.goto(`/game/${roomID}`);
+
+    await userPage.waitForURL("/");
+    await expect.poll(() => hostPage.getRoom(roomID)).toBeNull();
+  });
+
+  test("Should preserve a room when the host recovers before grace expires", async ({
+    hostPage,
+    userPage: {page: userPage}
+  }) => {
+    const roomName = uniqueRoomName("disconnect-grace-recovery");
+    const roomID = await hostPage.createRoom({roomName});
+    const hostLease = await hostPage.getHostLease(roomID);
+
+    expect(hostLease).not.toBeNull();
+
+    await hostPage.page.close();
+    await hostPage.renewHostLease(roomID, Date.now() - 26_000);
+    await hostPage.setDisconnectSignal(
+      roomID,
+      hostLease!.sessionId,
+      Date.now() - 25_000
+    );
+    await userPage.goto("/");
+
+    const roomCard = userPage.getByRole("button", {
+      name: new RegExp(roomName, "i")
+    });
+    await expect(roomCard).toBeVisible();
+
+    await hostPage.renewHostLease(roomID);
+    await hostPage.removeDisconnectSignals(roomID);
+    await userPage.waitForTimeout(6000);
+
+    await expect(roomCard).toBeVisible();
+    await expect
+      .poll(() => hostPage.getDisconnectSignal(roomID, hostLease!.sessionId))
+      .toBeNull();
+    await hostPage.removeRoom(roomID);
+  });
+
+  test("Should replace the host session and ignore obsolete renewals and signals", async ({
+    hostPage,
+    userPage: {page: userPage}
+  }) => {
+    const roomName = uniqueRoomName("replacement-session-room");
+    const roomID = await hostPage.createRoom({roomName});
+    const initialLease = await hostPage.getHostLease(roomID);
+    const room = await hostPage.getRoom(roomID);
+
+    expect(initialLease).not.toBeNull();
+    expect(room?.ownerUser?.key).toBeTruthy();
+
+    await hostPage.replaceHostLeaseSession(roomID, "obsolete-session");
+    await expect
+      .poll(async () => (await hostPage.getHostLease(roomID))?.sessionId)
+      .toBe(initialLease!.sessionId);
+
+    await hostPage.setDisconnectSignal(
+      roomID,
+      "obsolete-session",
+      Date.now() - 31_000
+    );
+    await userPage.goto("/");
+    await expect(
+      userPage.getByRole("button", {name: new RegExp(roomName, "i")})
+    ).toBeVisible();
+
+    await expect(
+      hostPage.attemptLeaseRenewal(
+        roomID,
+        room!.ownerUser.key!,
+        "obsolete-session"
+      )
+    ).resolves.toBe(false);
+    await expect.poll(() => hostPage.getRoom(roomID)).not.toBeNull();
+
+    await hostPage.removeRoom(roomID);
+  });
+
+  test("Should not recreate a room after deletion when an obsolete heartbeat arrives", async ({
+    hostPage,
+    userPage: {page: userPage}
+  }) => {
+    const roomName = uniqueRoomName("deleted-room-no-recreate");
+    const roomID = await hostPage.createRoom({roomName});
+    const initialLease = await hostPage.getHostLease(roomID);
+    const room = await hostPage.getRoom(roomID);
+
+    expect(initialLease).not.toBeNull();
+    expect(room?.ownerUser?.key).toBeTruthy();
+
+    await hostPage.page.close();
+    await hostPage.expireHostLease(roomID);
+    await userPage.goto("/");
+    await expect.poll(() => hostPage.getRoom(roomID)).toBeNull();
+
+    await expect(
+      hostPage.attemptLeaseRenewal(
+        roomID,
+        room!.ownerUser.key!,
+        initialLease!.sessionId
+      )
+    ).resolves.toBe(false);
+    await expect.poll(() => hostPage.getRoom(roomID)).toBeNull();
+  });
+
+  test("Should preserve a young pre-lease room with only legacy host evidence", async ({
+    hostPage,
+    userPage: {page: userPage}
+  }) => {
+    const roomName = uniqueRoomName("young-legacy-presence");
+    const roomID = await hostPage.createRoom({roomName});
+
+    await hostPage.page.close();
+    await hostPage.patchRoomLifecycle(roomID, {
+      created: Date.now() - 60 * 60 * 1000,
+      hostLease: null,
+      hostConnectionId: "legacy-host-only",
+      hostDisconnectedAt: null
+    });
+    await userPage.goto("/");
+
+    await expect(
+      userPage.getByRole("button", {name: new RegExp(roomName, "i")})
+    ).toBeVisible();
+    await expect
+      .poll(async () => (await hostPage.getRoom(roomID))?.hostConnectionId)
+      .toBe("legacy-host-only");
+    await hostPage.removeRoom(roomID);
+  });
+
+  test("Should bootstrap a lease when the authenticated owner opens a legacy room", async ({
+    hostPage
+  }) => {
+    const roomName = uniqueRoomName("legacy-bootstrap-room");
+    const roomID = await hostPage.createRoom({roomName});
+
+    await hostPage.patchRoomLifecycle(roomID, {
+      hostLease: null,
+      hostConnectionId: "legacy-host-only",
+      hostDisconnectedAt: null
+    });
+    await hostPage.page.goto(`/game/${roomID}`);
+    await hostPage.page.waitForURL(/\/game\//);
+
+    await expect.poll(() => hostPage.getHostLease(roomID)).not.toBeNull();
+    await hostPage.removeRoom(roomID);
+  });
+
+  test("Should clean an old pre-lease room even when a stale hostConnectionId remains", async ({
+    hostPage,
+    userPage: {page: userPage}
+  }) => {
+    const roomName = uniqueRoomName("legacy-connection-ghost");
+    const roomID = await hostPage.createRoom({roomName});
+
+    await hostPage.page.close();
+    await hostPage.patchRoomLifecycle(roomID, {
+      created: Date.now() - 25 * 60 * 60 * 1000,
+      hostLease: null,
+      hostConnectionId: "stale-legacy-connection",
+      hostDisconnectedAt: null
+    });
+    await userPage.goto("/");
+
+    await expect(
+      userPage.getByRole("button", {name: new RegExp(roomName, "i")})
+    ).not.toBeVisible();
+    await expect.poll(() => hostPage.getRoom(roomID)).toBeNull();
+  });
+
+  test("Should clean a legacy ghost room from the modern list without history", async ({
+    hostPage,
+    userPage: {page: userPage}
+  }) => {
+    const roomName = uniqueRoomName("legacy-ghost-modern");
+    const roomID = await hostPage.createRoom({roomName});
+
+    await hostPage.page.close();
+    await hostPage.patchRoomLifecycle(roomID, {
+      created: Date.now() - 25 * 60 * 60 * 1000,
+      hostLease: null,
+      hostConnectionId: null,
+      hostDisconnectedAt: null
+    });
+    await userPage.goto("/");
+
+    await expect(
+      userPage.getByRole("button", {name: new RegExp(roomName, "i")})
+    ).not.toBeVisible();
+    await expect.poll(() => hostPage.getRoom(roomID)).toBeNull();
+    expect(await hostPage.hasRoomHistory(roomID)).toBe(false);
+  });
+
+  test("Should clean a concurrent legacy ghost room idempotently", async ({
+    hostPage,
+    userPage: {page: userPage}
+  }) => {
+    const roomName = uniqueRoomName("legacy-ghost-concurrent");
+    const roomID = await hostPage.createRoom({roomName});
+
+    await hostPage.page.close();
+    await hostPage.patchRoomLifecycle(roomID, {
+      created: Date.now() - 25 * 60 * 60 * 1000,
+      hostLease: null,
+      hostConnectionId: null,
+      hostDisconnectedAt: null
+    });
+    const secondViewer = await userPage.context().newPage();
+
+    await Promise.all([userPage.goto("/"), secondViewer.goto("/")]);
+    await expect.poll(() => hostPage.getRoom(roomID)).toBeNull();
+    await secondViewer.close();
+  });
 });


### PR DESCRIPTION
## Summary
- add lease-based room lifecycle cleanup with 20s heartbeat, 90s expiry, and 30s disconnect grace via session-scoped signals
- prevent stale reconnect races with guarded room deletion and host session replacement handling
- add Playwright coverage, permission validation harness, and feature spec artifacts for ghost-room cleanup

## Validation
- npm exec tsc -- --noEmit -p .
- npx playwright test tests/e2e/auth.setup.ts --project=setup --workers=1
- npx playwright test tests/e2e/game.spec.ts --project=chromium --reporter=line --workers=1
- node scripts/verify-room-cleanup-rules.mjs (via isolated auth+database emulator harness)
